### PR TITLE
Allow for larger sand worlds by dividing world into dynamic chunks

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -1,32 +1,29 @@
 use crate::gridmath::*;
 
 pub struct Camera {
-    offset: GridVec,
+    center: GridVec,
     screen_size: GridVec,
-    scale_factor: u32,
 }
 
 impl Camera {
-    pub fn new(width: u32, height: u32, scale_factor: u32) -> Self {
+    pub fn new(width: u32, height: u32) -> Self {
         Camera { 
-            offset: GridVec::new(0, 0),
+            center: GridVec::new(0, 0),
             screen_size: GridVec::new(width as i32, height as i32),
-            scale_factor,
         }
     }
 
-    pub fn screen_to_world(&self, screen: ScreenPos) -> GridVec {
-        GridVec { x: (screen.x / self.scale_factor) as i32 + self.offset.x, 
-            y: (screen.y / self.scale_factor) as i32 + self.offset.y }
-    }
-
-    pub fn world_to_screen(&self, world: GridVec) -> ScreenPos {
-        ScreenPos { x: ((world.x * self.scale_factor as i32) - self.offset.x) as u32, 
-            y: ((world.y * self.scale_factor as i32) - self.offset.y) as u32 }
-    }
-
     pub fn move_by(&mut self, move_by: GridVec) {
-        self.offset = self.offset + move_by;
+        self.center = self.center + move_by;
+    }
+
+    pub fn bounds(&self) -> GridBounds {
+        GridBounds::new(self.center, self.screen_size / 2)
+    }
+
+    pub fn screen_to_world(&self, screen_pos: ScreenPos) -> GridVec {
+        let shifted = GridVec::new(screen_pos.x as i32, screen_pos.y as i32) - (self.screen_size / 2) + self.center;
+        return shifted;
     }
 }
 

--- a/src/gridmath.rs
+++ b/src/gridmath.rs
@@ -21,6 +21,25 @@ impl GridVec {
     pub fn new(x:i32, y:i32) -> Self {
         GridVec {x, y}
     }
+
+    /*
+        Concatenate the bits of the 2 coordinates into a single 64 bit value
+        Used for hashing and storage
+    */
+    pub fn combined(&self) -> u64 {
+        self.x as u64 | (self.y as u64) << 32
+    }
+
+    /*
+        Extract a grid coordinate from the bits of 2 coordinates combined into a 
+        single 64 bit value
+        Used for hashing and storage
+    */
+    pub fn decombined(combo: u64) -> GridVec {
+        GridVec::new(
+            (combo & 0x00000000FFFFFFFF) as i32, 
+            ((combo & 0xFFFFFFFF00000000) >> 32) as i32)
+    }
 }
 
 impl ops::Add<GridVec> for GridVec {
@@ -28,5 +47,57 @@ impl ops::Add<GridVec> for GridVec {
 
     fn add(self, rhs: GridVec) -> GridVec {
         GridVec{x: self.x + rhs.x, y: self.y + rhs.y}
+    }
+}
+
+impl ops::Sub<GridVec> for GridVec {
+    type Output = GridVec;
+
+    fn sub(self, rhs: GridVec) -> GridVec {
+        GridVec{x: self.x - rhs.x, y: self.y - rhs.y}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::gridmath::*;
+
+    #[test]
+    fn basic_addition() {
+        let a = GridVec::new(1, 0);
+        let b = GridVec::new(0, 2);
+        let result = a + b;
+        let expected = GridVec::new(1, 2);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn basic_subtraction() {
+        let a = GridVec::new(1, 0);
+        let b = GridVec::new(0, 2);
+        let result = a - b;
+        let expected = GridVec::new(1, -2);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn combination() {
+        let result = GridVec::new(4, 10).combined();
+        let expected = 0x0000000A00000004;
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn decombination() {
+        let result = GridVec::decombined(0x0000000A00000004);
+        let expected = GridVec::new(4, 10);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn combination_decombination() {
+        let result = GridVec::decombined(GridVec::new(4, 10).combined());
+        let expected = GridVec::new(4, 10);
+        assert_eq!(result, expected);
     }
 }

--- a/src/gridmath.rs
+++ b/src/gridmath.rs
@@ -27,6 +27,18 @@ impl GridVec {
         GridVec {x, y}
     }
 
+    pub fn manhattan_distance(&self, other: GridVec) -> i32 {
+        (self.x - other.x).abs() + (self.y - other.y).abs()
+    }
+
+    pub fn is_adjacent(&self, other: GridVec) -> bool {
+        match self.manhattan_distance(other) {
+            1 => true,
+            2 => (self.x - other.x).abs() == 1,
+            _ => false
+        }
+    }
+
     /*
         Concatenate the bits of the 2 coordinates into a single 64 bit value
         Used for hashing and storage
@@ -199,6 +211,51 @@ mod tests {
         let a = GridVec::new(1, 2);
         let result = a/ 2;
         let expected = GridVec::new(0, 1);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn manhattan_distance() {
+        let a = GridVec::new(1, 1);
+        let b = GridVec::new(-1, 0);
+        let result = a.manhattan_distance(b);
+        let expected = 3;
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn manhattan_distance_zero() {
+        let a = GridVec::new(1, 1);
+        let b = GridVec::new(1, 1);
+        let result = a.manhattan_distance(b);
+        let expected = 0;
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn adjacency_orthogonal() {
+        let a = GridVec::new(0, 0);
+        let b = GridVec::new(0, -1);
+        let result = a.is_adjacent(b);
+        let expected = true;
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn adjacency_diagonal() {
+        let a = GridVec::new(0, 0);
+        let b = GridVec::new(1, 1);
+        let result = a.is_adjacent(b);
+        let expected = true;
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn adjacency_miss() {
+        let a = GridVec::new(0, 0);
+        let b = GridVec::new(0, 2);
+        let result = a.is_adjacent(b);
+        let expected = false;
         assert_eq!(result, expected);
     }
 

--- a/src/gridmath.rs
+++ b/src/gridmath.rs
@@ -1,8 +1,8 @@
 use std::ops;
 use std::cmp;
 
-pub const WORLD_WIDTH: i32 = 720;
-pub const WORLD_HEIGHT: i32 = 480;
+pub const WORLD_WIDTH: i32 = 1920;
+pub const WORLD_HEIGHT: i32 = 1080;
 
 #[derive(PartialEq, Debug, Copy, Clone)]
 pub struct GridVec {

--- a/src/gridmath.rs
+++ b/src/gridmath.rs
@@ -1,14 +1,19 @@
 use std::ops;
+use std::cmp;
 
 pub const WORLD_WIDTH: i32 = 720;
 pub const WORLD_HEIGHT: i32 = 480;
-
-pub const SCALE_FACTOR: i32 = 2;
 
 #[derive(PartialEq, Debug, Copy, Clone)]
 pub struct GridVec {
     pub x: i32,
     pub y: i32,
+}
+
+#[derive(PartialEq, Debug, Copy, Clone)]
+pub struct GridBounds {
+    pub center: GridVec,
+    pub half_extent: GridVec,
 }
 
 #[derive(PartialEq, Debug, Copy, Clone)]
@@ -58,6 +63,107 @@ impl ops::Sub<GridVec> for GridVec {
     }
 }
 
+impl ops::Mul<i32> for GridVec {
+    type Output = GridVec;
+
+    fn mul(self, rhs: i32) -> GridVec {
+        GridVec{x: self.x * rhs, y: self.y * rhs}
+    }
+}
+
+impl ops::Div<i32> for GridVec {
+    type Output = GridVec;
+
+    fn div(self, rhs: i32) -> GridVec {
+        GridVec{x: self.x / rhs, y: self.y / rhs}
+    }
+}
+
+impl GridBounds {
+    pub fn new(center: GridVec, half_extent: GridVec) -> Self {
+        GridBounds { center, half_extent }
+    }
+
+    pub fn new_from_corner(bottom_left: GridVec, size: GridVec) -> Self {
+        let half_extent = size / 2;
+        GridBounds { center: bottom_left + half_extent, half_extent }
+    }
+
+    pub fn bottom_left(&self) -> GridVec {
+        self.center - self.half_extent    
+    }
+
+    pub fn top_right(&self) -> GridVec {
+        self.center + self.half_extent    
+    }
+
+    pub fn width(&self) -> u32 {
+        self.half_extent.x as u32 * 2
+    }
+
+    pub fn height(&self) -> u32 {
+        self.half_extent.y as u32 * 2
+    }
+
+    pub fn contains(&self, point: GridVec) -> bool {
+        let delta = point - self.center;
+        return delta.x.abs() <= self.half_extent.x && delta.y.abs() <= self.half_extent.y;
+    }
+
+    pub fn iter(&self) -> GridIterator {
+        GridIterator { bounds: self.clone(), current: self.bottom_left() + GridVec::new(-1, 0) }
+    }
+
+    // If there is an intersection, returns the bounds of the overlapping area
+    pub fn intersect(&self, other: GridBounds) -> Option<GridBounds> {
+        let dx = other.center.x - self.center.x;
+        let px = (other.half_extent.x + self.half_extent.x) - dx.abs();
+        if px <= 0 {
+            return None;
+        }
+
+        let dy = other.center.y - self.center.y;
+        let py = (other.half_extent.y + self.half_extent.y) - dy.abs();
+        if py <= 0 {
+            return None;
+        }
+
+        let bottom_left = GridVec::new(
+            cmp::max(self.bottom_left().x, other.bottom_left().x),
+            cmp::max(self.bottom_left().y, other.bottom_left().y)
+        );
+        let top_right = GridVec::new(
+            cmp::min(self.top_right().x, other.top_right().x),
+            cmp::min(self.top_right().y, other.top_right().y)
+        );
+        let size = top_right - bottom_left;
+        return Some(GridBounds::new_from_corner(bottom_left, size));
+    }
+}
+
+pub struct GridIterator {
+    bounds: GridBounds,
+    current: GridVec,
+}
+
+impl Iterator for GridIterator {
+    type Item = GridVec;
+
+    fn next(&mut self) -> Option<GridVec> {
+        self.current.x += 1;
+        if self.current.x >= self.bounds.top_right().x {
+            self.current.x = self.bounds.bottom_left().x;
+            self.current.y += 1;
+
+            if self.current.y >= self.bounds.top_right().y {
+                return None
+            }
+        }
+
+        return Some(self.current);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::gridmath::*;
@@ -81,6 +187,22 @@ mod tests {
     }
 
     #[test]
+    fn basic_multiplication() {
+        let a = GridVec::new(1, 2);
+        let result = a * 2;
+        let expected = GridVec::new(2, 4);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn basic_division() {
+        let a = GridVec::new(1, 2);
+        let result = a/ 2;
+        let expected = GridVec::new(0, 1);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
     fn combination() {
         let result = GridVec::new(4, 10).combined();
         let expected = 0x0000000A00000004;
@@ -98,6 +220,36 @@ mod tests {
     fn combination_decombination() {
         let result = GridVec::decombined(GridVec::new(4, 10).combined());
         let expected = GridVec::new(4, 10);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn overlap_none() {
+        let a = GridBounds::new(GridVec::new(0, 0), GridVec::new(1, 1));
+        let b = GridBounds::new(GridVec::new(3, 0), GridVec::new(1, 1));
+
+        let result = a.intersect(b);
+        let expected = None;
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn overlap_contained() {
+        let a = GridBounds::new(GridVec::new(0, 0), GridVec::new(1, 1));
+        let b = GridBounds::new(GridVec::new(0, 0), GridVec::new(10, 10));
+
+        let result = a.intersect(b);
+        let expected = Some(a);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn overlap_partial() {
+        let a = GridBounds::new(GridVec::new(0, 0), GridVec::new(2, 2));
+        let b = GridBounds::new(GridVec::new(1, 1), GridVec::new(2, 2));
+
+        let result = a.intersect(b);
+        let expected = Some(GridBounds::new(GridVec::new(0, 0), GridVec::new(1, 1)));
         assert_eq!(result, expected);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,8 +20,8 @@ use crate::sandworld::*;
 use crate::input::*;
 use crate::camera::*;
 
-const SCREEN_WIDTH: u32 = (WORLD_WIDTH) as u32;
-const SCREEN_HEIGHT: u32 = (WORLD_HEIGHT) as u32;
+const SCREEN_WIDTH: u32 = 1920;
+const SCREEN_HEIGHT: u32 = 1080;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,8 +20,8 @@ use crate::sandworld::*;
 use crate::input::*;
 use crate::camera::*;
 
-const SCREEN_WIDTH: u32 = 1920;
-const SCREEN_HEIGHT: u32 = 1080;
+const SCREEN_WIDTH: u32 = 720;
+const SCREEN_HEIGHT: u32 = 480;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,8 +21,8 @@ use crate::sandworld::*;
 use crate::input::*;
 use crate::camera::*;
 
-const SCREEN_WIDTH: u32 = (WORLD_WIDTH * SCALE_FACTOR) as u32;
-const SCREEN_HEIGHT: u32 = (WORLD_HEIGHT * SCALE_FACTOR) as u32;
+const SCREEN_WIDTH: u32 = (WORLD_WIDTH) as u32;
+const SCREEN_HEIGHT: u32 = (WORLD_HEIGHT) as u32;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
@@ -42,7 +42,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
     let mut world = World::new();
     let mut input = InputState::new();
-    let mut camera = Camera::new(SCREEN_WIDTH, SCREEN_HEIGHT, 2);
+    let mut camera = Camera::new(SCREEN_WIDTH, SCREEN_HEIGHT);
 
     'game_loop: loop {
         while let Some(event) = sdl.poll_event() {
@@ -130,23 +130,22 @@ fn update(world: &mut World, cam: &mut Camera, input: &InputState) {
 }
 
 fn draw(world: &World, cam: &Camera, frame: &mut [u8]) {
+    let cam_bounds = cam.bounds();
+    let visible_part_buffer = world.render(&cam_bounds);
+
     for (i, pixel) in frame.chunks_exact_mut(4).enumerate() {
         let x = (i % SCREEN_WIDTH as usize) as u32;
         let y = SCREEN_HEIGHT - (i / SCREEN_WIDTH as usize) as u32 - 1;
 
-        let screen_pos = ScreenPos{x, y};
-        let world_pos = cam.screen_to_world(screen_pos);
+        let buffer_index = (x + y * cam_bounds.width()) as usize;
 
-        let mut rgba = [0x00, 0x00, 0x00, 0xff];
-
-        if world.contains(world_pos) {
-            rgba = match world.get_particle(world_pos).particle_type {
+        let rgba = match visible_part_buffer[buffer_index].particle_type {
                 sandworld::ParticleType::Sand => [0xdc, 0xcd, 0x79, 0xff],
                 sandworld::ParticleType::Water => [0x56, 0x9c, 0xd6, 0xff],
                 sandworld::ParticleType::Stone => [0xd4, 0xd4, 0xd4, 0xff],
-                _ => [0x1e, 0x1e, 0x1e, 0xff],
-            };
-        }
+                sandworld::ParticleType::Air => [0x1e, 0x1e, 0x1e, 0xff],
+                _ => [0x00, 0x00, 0x00, 0xff],
+        };
 
         pixel.copy_from_slice(&rgba);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 #![deny(clippy::all)]
-#![forbid(unsafe_code)]
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 use beryllium::{

--- a/src/sandworld.rs
+++ b/src/sandworld.rs
@@ -97,7 +97,7 @@ impl Default for Particle {
 
 impl Chunk {
     fn new(position: GridVec) -> Self {
-        let mut created = Chunk {
+        let created = Chunk {
             position,
             neighbors: Neighbors::new(),
             particles: [Particle::default(); CHUNK_SIZE as usize *  CHUNK_SIZE as usize],
@@ -467,6 +467,10 @@ impl World {
                     let buffer_index = (buffer_local.x + (buffer_width * buffer_local.y)) as usize;
 
                     outbuffer[buffer_index] = chunk.get_particle(chunk_local.x as u8, chunk_local.y as u8);
+
+                    if chunk_local.x == 0 || chunk_local.y == 0 || chunk_local.x as u8 == CHUNK_SIZE - 1 || chunk_local.y as u8 == CHUNK_SIZE - 1 {
+                        outbuffer[buffer_index] = Particle::new(ParticleType::Boundary);
+                    }
                 }
             }
         }

--- a/src/sandworld.rs
+++ b/src/sandworld.rs
@@ -467,10 +467,6 @@ impl World {
                     let buffer_index = (buffer_local.x + (buffer_width * buffer_local.y)) as usize;
 
                     outbuffer[buffer_index] = chunk.get_particle(chunk_local.x as u8, chunk_local.y as u8);
-
-                    if chunk_local.x == 0 || chunk_local.y == 0 || chunk_local.x as u8 == CHUNK_SIZE - 1 || chunk_local.y as u8 == CHUNK_SIZE - 1 {
-                        outbuffer[buffer_index] = Particle::new(ParticleType::Boundary);
-                    }
                 }
             }
         }


### PR DESCRIPTION
Splits allocation to happen in smaller sub-grids of the world to allow for the world to be allocated dynamically on the heap to avoid stack size limitations. This also paves the way for future optimizations such as only running update on chunks that are dirty and parallelization. This required a significant rewrite of several parts of the code.