### PR TITLE
Allow the UI to consume clicks

### DIFF
--- a/sandworld/src/chunk.rs
+++ b/sandworld/src/chunk.rs
@@ -1,4 +1,3 @@
-
 pub const CHUNK_SIZE: u8 = 64;
 use gridmath::*;
 use rand::{Rng};

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -5,7 +5,7 @@ pub struct CameraPlugin;
 impl Plugin for CameraPlugin {
     fn build(&self, app: &mut App) {
         app.add_startup_system(spawn_camera)
-        .add_system(camera_movement);
+        .add_system(camera_movement.label(crate::UpdateStages::Input));
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,15 @@ mod sandsim;
 mod camera;
 mod ui;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(SystemLabel)]
+enum UpdateStages {
+    UI,
+    Input,
+    WorldUpdate,
+    WorldDraw,
+}
+
 fn main(){
     App::new()
         .add_plugins(DefaultPlugins)


### PR DESCRIPTION
This prevents accidental particle placement when attempting to click a tool selector button.

Also labels all the existing systems to allow for more convenient ordering. Some of this was needed to make sure the UI processing happened before the sand placement so that the click could be consumed before it reached that, but I just labeled the rest while I was at it.