### PR TITLE
Large worlds through regions

### DIFF
--- a/gridmath/src/gridbounds.rs
+++ b/gridmath/src/gridbounds.rs
@@ -107,6 +107,10 @@ impl GridBounds {
         )
     }
 
+    pub fn area(&self) -> u32 {
+        self.width() * self.height()
+    }
+
     pub fn iter(&self) -> GridIterator {
         GridIterator { bounds: self.clone(), current: self.bottom_left() + GridVec::new(-1, 0) }
     }

--- a/gridmath/src/gridbounds.rs
+++ b/gridmath/src/gridbounds.rs
@@ -10,6 +10,12 @@ pub struct GridBounds {
     pub top_right: GridVec,
 }
 
+impl std::fmt::Display for GridBounds {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "<from {} to {}>", self.bottom_left(), self.top_right())
+    }
+}
+
 impl GridBounds {
     pub fn new(center: GridVec, half_extent: GridVec) -> Self {
         GridBounds { bottom_left: center - half_extent, top_right: center + half_extent }
@@ -149,6 +155,22 @@ impl GridBounds {
         else {
             None
         }
+    }
+
+    pub fn overlaps(&self, other: GridBounds) -> bool {
+        let dx = other.center().x - self.center().x;
+        let px = (other.half_extent().x + self.half_extent().x) - dx.abs();
+        if px <= 0 {
+            return false;
+        }
+
+        let dy = other.center().y - self.center().y;
+        let py = (other.half_extent().y + self.half_extent().y) - dy.abs();
+        if py <= 0 {
+            return false;
+        }
+
+        true
     }
 
     // If there is an intersection, returns the bounds of the overlapping area

--- a/sandworld/src/chunk.rs
+++ b/sandworld/src/chunk.rs
@@ -99,7 +99,7 @@ impl Chunk {
             updated_last_frame: None,
         };
 
-        println!("Created new chunk at {}", position);
+        //println!("Created new chunk at {}", position);
 
         return created;
     }

--- a/sandworld/src/chunk.rs
+++ b/sandworld/src/chunk.rs
@@ -461,7 +461,7 @@ impl Chunk {
         self.updated_last_frame = self.update_this_frame;
     }
 
-    pub(crate) fn _check_remove_neighbor(&mut self, removed_position: GridVec) {
+    pub(crate) fn check_remove_neighbor(&mut self, removed_position: GridVec) {
         if !self.position.is_adjacent(removed_position) {
             return;
         }

--- a/sandworld/src/chunk.rs
+++ b/sandworld/src/chunk.rs
@@ -99,8 +99,6 @@ impl Chunk {
             updated_last_frame: None,
         };
 
-        //println!("Created new chunk at {}", position);
-
         return created;
     }
     

--- a/sandworld/src/chunk.rs
+++ b/sandworld/src/chunk.rs
@@ -1,7 +1,7 @@
 pub const CHUNK_SIZE: u8 = 64;
 use gridmath::*;
 use rand::{Rng, rngs::ThreadRng};
-
+use crate::region::REGION_SIZE;
 use crate::particle::*;
 
 pub struct Chunk {
@@ -132,7 +132,18 @@ impl Chunk {
                 let mut color = get_color_for_type(part);
 
                 if draw_borders {
-                    if x == 0 || y == 0 || x == CHUNK_SIZE - 1 || y == CHUNK_SIZE - 1 {
+                    if (x == 0 && self.position.x % REGION_SIZE as i32 == 0) 
+                    || (x == CHUNK_SIZE - 1 && (self.position.x + 1) % REGION_SIZE as i32 == 0) {
+                        color = get_color_for_type(ParticleType::RegionBoundary);
+                    } 
+                    else if x == 0 || x == CHUNK_SIZE - 1 {
+                        color = get_color_for_type(ParticleType::Boundary);
+                    }
+                    else if (y == CHUNK_SIZE - 1 && self.position.y % REGION_SIZE as i32 == 0) 
+                    || (y == 0 && (self.position.y + 1) % REGION_SIZE as i32 == 0) {
+                        color = get_color_for_type(ParticleType::RegionBoundary);
+                    } 
+                    else if y == 0 || y == CHUNK_SIZE - 1 {
                         color = get_color_for_type(ParticleType::Boundary);
                     }
                 }

--- a/sandworld/src/chunk.rs
+++ b/sandworld/src/chunk.rs
@@ -99,6 +99,8 @@ impl Chunk {
             updated_last_frame: None,
         };
 
+        println!("Created new chunk at {}", position);
+
         return created;
     }
     

--- a/sandworld/src/chunk.rs
+++ b/sandworld/src/chunk.rs
@@ -305,6 +305,9 @@ impl Chunk {
                 new_chunk.neighbors.bottom_left = Some(self);
             }
         }
+
+        self.mark_dirty(0, 0);
+        self.mark_dirty(CHUNK_SIZE as i32, CHUNK_SIZE as i32)
     }
 
     pub fn chunkpos_to_local_chunkpos(&self, from_chunk: &Chunk, from_x: u8, from_y: u8) -> GridVec {

--- a/sandworld/src/lib.rs
+++ b/sandworld/src/lib.rs
@@ -1,5 +1,6 @@
 mod particle;
 mod chunk;
+mod region;
 mod sandworld;
 
 pub use sandworld::*;

--- a/sandworld/src/particle.rs
+++ b/sandworld/src/particle.rs
@@ -8,6 +8,7 @@ pub enum ParticleType {
     Stone,
     Source,
     Boundary,
+    RegionBoundary,
     Dirty,
 }
 
@@ -51,6 +52,7 @@ pub fn get_color_for_type(particle_type: ParticleType) -> [u8; 4] {
         ParticleType::Air => [0x1e, 0x1e, 0x1e, 0xff],
         ParticleType::Source => [0xf7, 0xdf, 0x00, 0xff],
         ParticleType::Dirty => [0xFF, 0x00, 0xFF, 0xff],
+        ParticleType::RegionBoundary => [0xFF, 0xFF, 0x00, 0xFF],
         _ => [0x00, 0x00, 0x00, 0xff],
     }
 }

--- a/sandworld/src/region.rs
+++ b/sandworld/src/region.rs
@@ -1,4 +1,4 @@
-pub const REGION_SIZE: usize = 16;
+pub const REGION_SIZE: usize = 2;
 
 use std::sync::atomic::AtomicU64;
 
@@ -23,13 +23,15 @@ impl Region {
             added_chunks: vec![],
             updated_chunks: vec![],
         };
+        println!("Created new region at {}, creating chunks", position);
 
         for y in 0..REGION_SIZE as i32 {
             for x in 0..REGION_SIZE as i32 {
-                reg.add_chunk(GridVec::new(x, y));
+                reg.add_chunk(GridVec::new(x, y) + (position * REGION_SIZE as i32));
             }
         }
 
+        println!("Finished creating chunks for region {}", position);
         reg
     }
 

--- a/sandworld/src/region.rs
+++ b/sandworld/src/region.rs
@@ -111,6 +111,72 @@ impl Region {
         }
     }
 
+    pub(crate) fn check_remove_neighbor(&mut self, other_regpos: &GridVec) {
+        if !self.position.is_adjacent(*other_regpos) {
+            return;
+        }
+
+        let delta = *other_regpos - self.position;
+
+        let mut self_chunks = Vec::new();
+        let mut other_chunks = Vec::new();
+
+        if delta.y == -1 {
+            if delta.x == -1 { 
+                self_chunks.push(GridVec::new(0, 0));
+                other_chunks.push(GridVec::new(REGION_SIZE as i32 - 1 , REGION_SIZE as i32 - 1));
+            }
+            else if delta.x == 0 {
+                for x in 0..REGION_SIZE as i32 {
+                    self_chunks.push(GridVec::new(x, 0));
+                    other_chunks.push(GridVec::new(x , REGION_SIZE as i32 - 1));
+                }
+            }
+            else if delta.x == 1 {
+                self_chunks.push(GridVec::new(REGION_SIZE as i32 - 1, 0));
+                other_chunks.push(GridVec::new(0 , REGION_SIZE as i32 - 1));
+            }
+        }
+        else if delta.y == 0 {
+            if delta.x == -1 { 
+                for y in 0..REGION_SIZE as i32 {
+                    self_chunks.push(GridVec::new(0, y));
+                    other_chunks.push(GridVec::new(REGION_SIZE as i32 - 1 , y));
+                }
+            }
+            else if delta.x == 1 {
+                for y in 0..REGION_SIZE as i32 {
+                    self_chunks.push(GridVec::new(REGION_SIZE as i32 - 1, y));
+                    other_chunks.push(GridVec::new(0 , y));
+                }
+            }
+        }
+        else if delta.y == 1 {
+            if delta.x == -1 { 
+                self_chunks.push(GridVec::new(0 , REGION_SIZE as i32 - 1));
+                other_chunks.push(GridVec::new(REGION_SIZE as i32 - 1, 0));
+            }
+            else if delta.x == 0 {
+                for x in 0..REGION_SIZE as i32 {
+                    self_chunks.push(GridVec::new(x, REGION_SIZE as i32 - 1));
+                    other_chunks.push(GridVec::new(x , 0));
+                }
+            }
+            else if delta.x == 1 {
+                self_chunks.push(GridVec::new(REGION_SIZE as i32 - 1 , REGION_SIZE as i32 - 1));
+                other_chunks.push(GridVec::new(0, 0));
+            }
+        }
+
+        for self_chunk_pos in self_chunks.iter() {
+            for other_chunk_pos in other_chunks.iter() {
+                let self_chunk = &mut self.chunks[Region::local_chunkpos_to_region_index(self_chunk_pos)];
+                
+                self_chunk.check_remove_neighbor(*other_chunk_pos);
+            }
+        }
+    }
+
     fn _chunkpos_from_region_index(region_pos: GridVec, index: usize) -> GridVec {
         let x = (index % REGION_SIZE) as i32 + (region_pos.x * REGION_SIZE as i32);
         let y = (index / REGION_SIZE) as i32 + (region_pos.y * REGION_SIZE as i32);

--- a/sandworld/src/region.rs
+++ b/sandworld/src/region.rs
@@ -23,15 +23,13 @@ impl Region {
             added_chunks: vec![],
             updated_chunks: vec![],
         };
-        println!("Created new region at {}, creating chunks", position);
-
+        
         for y in 0..REGION_SIZE as i32 {
             for x in 0..REGION_SIZE as i32 {
                 reg.add_chunk(GridVec::new(x, y) + (position * REGION_SIZE as i32));
             }
         }
 
-        println!("Finished creating chunks for region {}", position);
         reg
     }
 

--- a/sandworld/src/region.rs
+++ b/sandworld/src/region.rs
@@ -277,6 +277,7 @@ impl Region {
 
     pub fn commit_updates(&mut self) {
         self.staleness = 0;
+        self.last_chunk_updates = 0;
 
         self.chunks.iter().for_each(|chunk| {
             if chunk.dirty.is_some() || chunk.updated_last_frame.is_some()  {
@@ -307,7 +308,7 @@ impl Region {
         });
         
         let updated = updated_count.load(std::sync::atomic::Ordering::Relaxed);
-        self.last_chunk_updates = updated;
+        self.last_chunk_updates += updated;
         updated
     }
 }

--- a/sandworld/src/region.rs
+++ b/sandworld/src/region.rs
@@ -9,6 +9,7 @@ use crate::{chunk::*, World, Particle, ParticleType};
 pub struct Region {
     pub position: GridVec,
     pub staleness: u32, // Number of updates this region has been skipped
+    pub last_chunk_updates: u64, // Number of chunks updated last time this region updated
     chunks: Vec<Box<Chunk>>,
     // Chunks that have been added to the world since last polled
     added_chunks: Vec<GridVec>,
@@ -21,6 +22,7 @@ impl Region {
         let mut reg = Region {
             position,
             staleness: 0,
+            last_chunk_updates: 0,
             chunks: vec![],
             added_chunks: vec![],
             updated_chunks: vec![],
@@ -304,6 +306,8 @@ impl Region {
             }
         });
         
-        updated_count.load(std::sync::atomic::Ordering::Relaxed)
+        let updated = updated_count.load(std::sync::atomic::Ordering::Relaxed);
+        self.last_chunk_updates = updated;
+        updated
     }
 }

--- a/sandworld/src/region.rs
+++ b/sandworld/src/region.rs
@@ -1,0 +1,150 @@
+pub const REGION_SIZE: usize = 16;
+
+use std::sync::atomic::AtomicU64;
+
+use gridmath::*;
+use rayon::prelude::*;
+use crate::{chunk::*, World, Particle, ParticleType};
+
+pub struct Region {
+    pub position: GridVec,
+    chunks: Vec<Box<Chunk>>,
+    // Chunks that have been added to the world since last polled
+    added_chunks: Vec<GridVec>,
+    // Chunks that have been updated since last polled
+    updated_chunks: Vec<GridVec>,
+}
+
+impl Region {
+    pub fn new(position: GridVec) -> Self {
+        let mut reg = Region {
+            position,
+            chunks: vec![],
+            added_chunks: vec![],
+            updated_chunks: vec![],
+        };
+
+        for y in 0..REGION_SIZE as i32 {
+            for x in 0..REGION_SIZE as i32 {
+                reg.add_chunk(GridVec::new(x, y));
+            }
+        }
+
+        reg
+    }
+
+    fn add_chunk(&mut self, chunkpos: GridVec) {
+        let mut added = Box::new(Chunk::new(chunkpos));
+
+        for chunk in self.chunks.iter_mut() {
+            chunk.check_add_neighbor(&mut added);
+        }
+
+        self.chunks.push(added);
+        self.added_chunks.push(chunkpos);
+    }
+
+    fn _chunkpos_from_region_index(region_pos: GridVec, index: usize) -> GridVec {
+        let x = (index % REGION_SIZE) as i32 + (region_pos.x * REGION_SIZE as i32);
+        let y = (index / REGION_SIZE) as i32 + (region_pos.y * REGION_SIZE as i32);
+        GridVec { x, y }
+    }
+
+    fn chunkpos_to_region_index(&self, chunkpos: &GridVec) -> usize {
+        let x = chunkpos.x - (self.position.x * REGION_SIZE as i32);
+        let y = chunkpos.y - (self.position.y * REGION_SIZE as i32);
+
+        #[cfg(debug_assertions)] {
+            if x < 0 || x >= REGION_SIZE as i32 || y < 0 || y >= REGION_SIZE as i32 {
+                println!("Chunk position of {} is not within region at {}", chunkpos, self.position);
+            }
+        }
+
+        x as usize + (y as usize * REGION_SIZE)
+    }
+
+    pub fn contains_chunk(&self, chunkpos: &GridVec) -> bool {
+        let x = chunkpos.x - (self.position.x * REGION_SIZE as i32);
+        let y = chunkpos.y - (self.position.y * REGION_SIZE as i32);
+
+        x >= 0 && x < REGION_SIZE as i32 && y >= 0 && y < REGION_SIZE as i32
+    }
+
+    pub fn contains_point(&self, pos: &GridVec) -> bool {
+        self.contains_chunk(&World::get_chunkpos(pos))
+    }
+
+    pub fn get_particle(&self, pos: GridVec) -> Particle {
+        let chunk_opt = self.get_chunk(&World::get_chunkpos(&pos));
+        if let Some(chunk) = chunk_opt {
+            let chunklocal = World::get_chunklocal(pos);
+            chunk.get_particle(chunklocal.x as u8, chunklocal.y as u8)
+        }
+        else {
+            Particle::new(ParticleType::Boundary)
+        }
+    }
+
+    pub fn get_added_chunks(&mut self) -> Vec<GridVec> {
+        let set = self.added_chunks.clone();
+        self.added_chunks.clear();
+        return set;
+    }
+
+    pub fn get_updated_chunks(&mut self) -> Vec<GridVec> {
+        let set = self.updated_chunks.clone();
+        self.updated_chunks.clear();
+        return set;
+    }
+
+    pub fn get_chunk(&self, chunkpos: &GridVec) -> Option<&Box<Chunk>> {
+        if self.contains_chunk(chunkpos) {
+            Some(&self.chunks[self.chunkpos_to_region_index(chunkpos)])
+        }
+        else {
+            None
+        }
+    }
+
+    pub fn get_chunk_mut(&mut self, chunkpos: &GridVec) -> Option<&mut Box<Chunk>> {
+        if self.contains_chunk(chunkpos) {
+            let index = self.chunkpos_to_region_index(chunkpos);
+            Some(&mut self.chunks[index])
+        }
+        else {
+            None
+        }
+    }
+
+    pub fn commit_updates(&mut self) {
+        self.chunks.iter().for_each(|chunk| {
+            if chunk.dirty.is_some() || chunk.updated_last_frame.is_some()  {
+                self.updated_chunks.push(chunk.position);
+            }
+        });
+
+        self.chunks.par_iter_mut().for_each(|chunk| {
+            chunk.commit_updates();
+        });
+    }
+
+    pub fn update(&mut self, phase: i32) -> u64 {
+        let updated_count = AtomicU64::new(0);
+
+        let x_mod = (phase) % 2;
+        let y_mod = ((phase) / 2) % 2; 
+
+        self.chunks.par_iter_mut().for_each(|chunk| {
+            let chunk_pos = chunk.position;
+
+            if chunk_pos.x % 2 == x_mod && chunk_pos.y % 2 == y_mod {
+                if chunk.update_this_frame.is_some() || chunk.updated_last_frame.is_some() { 
+                    updated_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    chunk.update(); 
+                }
+            }
+        });
+        
+        updated_count.load(std::sync::atomic::Ordering::Relaxed)
+    }
+}

--- a/sandworld/src/region.rs
+++ b/sandworld/src/region.rs
@@ -1,4 +1,4 @@
-pub const REGION_SIZE: usize = 2;
+pub const REGION_SIZE: usize = 8;
 
 use std::sync::atomic::AtomicU64;
 

--- a/sandworld/src/region.rs
+++ b/sandworld/src/region.rs
@@ -23,7 +23,7 @@ impl Region {
             added_chunks: vec![],
             updated_chunks: vec![],
         };
-        
+
         for y in 0..REGION_SIZE as i32 {
             for x in 0..REGION_SIZE as i32 {
                 reg.add_chunk(GridVec::new(x, y) + (position * REGION_SIZE as i32));
@@ -137,7 +137,7 @@ impl Region {
         self.chunks.par_iter_mut().for_each(|chunk| {
             let chunk_pos = chunk.position;
 
-            if chunk_pos.x % 2 == x_mod && chunk_pos.y % 2 == y_mod {
+            if (chunk_pos.x % 2).abs() == x_mod && (chunk_pos.y % 2).abs() == y_mod {
                 if chunk.update_this_frame.is_some() || chunk.updated_last_frame.is_some() { 
                     updated_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                     chunk.update(); 

--- a/sandworld/src/sandworld.rs
+++ b/sandworld/src/sandworld.rs
@@ -79,7 +79,14 @@ impl World {
     }
 
     pub(crate) fn get_chunkpos(pos: &GridVec) -> GridVec {
-        GridVec::new(pos.x / CHUNK_SIZE as i32, pos.y / CHUNK_SIZE as i32)
+        let mut modpos = pos.clone();
+        if modpos.x < 0 {
+            modpos.x -= CHUNK_SIZE as i32;
+        }
+        if modpos.y < 0 {
+            modpos.y -= CHUNK_SIZE as i32;
+        }
+        GridVec::new(modpos.x / CHUNK_SIZE as i32, modpos.y / CHUNK_SIZE as i32)
     }
 
     pub(crate) fn get_chunklocal(pos: GridVec) -> GridVec {
@@ -120,6 +127,7 @@ impl World {
 
         let chunkpos = World::get_chunkpos(&pos);
         let chunklocal = World::get_chunklocal(pos);
+
         self.get_chunk_mut(&chunkpos).unwrap().add_particle(chunklocal.x as u8, chunklocal.y as u8, new_val);
     }
 

--- a/sandworld/src/sandworld.rs
+++ b/sandworld/src/sandworld.rs
@@ -215,12 +215,16 @@ impl World {
             self.add_region_if_needed(regpos);
         }
 
+        let visible_region_count = visible_regions.area();
+        let total_visible_priority_boost = 65536;
+        let visible_boost_per_region = (total_visible_priority_boost / visible_region_count) as u64;
+
         let updated_chunk_count = AtomicU64::new(0);
         let updated_region_count = AtomicU64::new(0);
 
         self.regions.par_sort_unstable_by(|a, b| {
-            let a_val = a.update_priority + if a.get_bounds().overlaps(visible) { 1024 } else { 0 };
-            let b_val = b.update_priority + if b.get_bounds().overlaps(visible) { 1024 } else { 0 };
+            let a_val = a.update_priority + if a.get_bounds().overlaps(visible) { visible_boost_per_region } else { 0 };
+            let b_val = b.update_priority + if b.get_bounds().overlaps(visible) { visible_boost_per_region } else { 0 };
             
             b_val.cmp(&a_val)
         });

--- a/sandworld/src/sandworld.rs
+++ b/sandworld/src/sandworld.rs
@@ -21,6 +21,8 @@ impl World {
         };
 
         created.regions.push(Region::new(GridVec::new(0, 0)));
+        created.regions.push(Region::new(GridVec::new(1, 0)));
+        created.regions.push(Region::new(GridVec::new(-1, 0)));
 
         return created;
     }
@@ -36,7 +38,7 @@ impl World {
 
     pub(crate) fn get_chunk_mut(&mut self, chunkpos: &GridVec) -> Option<&mut Box<Chunk>> {
         for reg in self.regions.iter_mut() {
-            if reg.contains_point(chunkpos) {
+            if reg.contains_chunk(chunkpos) {
                 return reg.get_chunk_mut(chunkpos);
             }
         }
@@ -45,7 +47,7 @@ impl World {
 
     pub fn get_chunk(&self, chunkpos: &GridVec) -> Option<&Box<Chunk>> {
         for reg in self.regions.iter() {
-            if reg.contains_point(chunkpos) {
+            if reg.contains_chunk(chunkpos) {
                 return reg.get_chunk(chunkpos);
             }
         }

--- a/sandworld/src/sandworld.rs
+++ b/sandworld/src/sandworld.rs
@@ -220,7 +220,7 @@ impl World {
         }
     }
 
-    pub fn update(&mut self, visible: GridBounds) -> WorldUpdateStats {
+    pub fn update(&mut self, visible: GridBounds, target_chunk_updates: u64) -> WorldUpdateStats {
         let visible_regions = GridBounds::new_from_extents(
             Self::get_regionpos_for_pos(&visible.bottom_left()),
             Self::get_regionpos_for_pos(&visible.top_right()) + GridVec::new(1, 1)
@@ -232,8 +232,6 @@ impl World {
 
         let updated_chunk_count = AtomicU64::new(0);
         let updated_region_count = AtomicU64::new(0);
-
-        let target_chunk_updates = 128;
 
         self.regions.sort_unstable_by(|a, b| {
             let mut a_val = if a.get_bounds().overlaps(visible) { 1024 } else { 0 };

--- a/sandworld/src/sandworld.rs
+++ b/sandworld/src/sandworld.rs
@@ -91,10 +91,10 @@ impl World {
     pub(crate) fn get_chunkpos(pos: &GridVec) -> GridVec {
         let mut modpos = pos.clone();
         if modpos.x < 0 {
-            modpos.x -= CHUNK_SIZE as i32;
+            modpos.x -= CHUNK_SIZE as i32 - 1;
         }
         if modpos.y < 0 {
-            modpos.y -= CHUNK_SIZE as i32;
+            modpos.y -= CHUNK_SIZE as i32 - 1;
         }
         GridVec::new(modpos.x / CHUNK_SIZE as i32, modpos.y / CHUNK_SIZE as i32)
     }

--- a/sandworld/src/sandworld.rs
+++ b/sandworld/src/sandworld.rs
@@ -20,19 +20,29 @@ impl World {
             regions: Vec::new()
         };
 
-        created.regions.push(Region::new(GridVec::new(0, 0)));
-        created.regions.push(Region::new(GridVec::new(1, 0)));
-        created.regions.push(Region::new(GridVec::new(-1, 0)));
+        created.add_region(GridVec::new(0, 0));
+        created.add_region(GridVec::new(1, 0));
+        created.add_region(GridVec::new(-1, 0));
 
-        created.regions.push(Region::new(GridVec::new(0, -1)));
-        created.regions.push(Region::new(GridVec::new(1, -1)));
-        created.regions.push(Region::new(GridVec::new(-1, -1)));
+        created.add_region(GridVec::new(0, -1));
+        created.add_region(GridVec::new(1, -1));
+        created.add_region(GridVec::new(-1, -1));
 
-        created.regions.push(Region::new(GridVec::new(0, 1)));
-        created.regions.push(Region::new(GridVec::new(1, 1)));
-        created.regions.push(Region::new(GridVec::new(-1, 1)));
+        created.add_region(GridVec::new(0, 1));
+        created.add_region(GridVec::new(1, 1));
+        created.add_region(GridVec::new(-1, 1));
 
         return created;
+    }
+
+    fn add_region(&mut self, regpos: GridVec) {
+        let mut added = Region::new(regpos);
+
+        for region in self.regions.iter_mut() {
+            region.check_add_neighbor(&mut added);
+        }
+
+        self.regions.push(added);
     }
 
     pub fn contains(&self, pos: GridVec) -> bool {

--- a/sandworld/src/sandworld.rs
+++ b/sandworld/src/sandworld.rs
@@ -1,80 +1,78 @@
 use gridmath::*;
 use rand::{RngCore};
 use rayon::prelude::*;
-use std::{collections::HashMap, sync::atomic::AtomicU64};
+use std::{sync::atomic::AtomicU64};
 
 use crate::chunk::*;
 use crate::particle::*;
+use crate::region::*;
 
 pub const WORLD_WIDTH: i32 = 1440;
 pub const WORLD_HEIGHT: i32 = 960;
 
 pub struct World {
-    chunks: HashMap<u64, Box<Chunk>>,
-    // Chunks that have been added to the world since last polled
-    added_chunks: Vec<GridVec>,
-    // Chunks that have been updated since last polled
-    updated_chunks: Vec<GridVec>,
+    regions: Vec<Region>
 }
 
 impl World {
     pub fn new() -> Self {
         let mut created: World = World {
-            chunks: HashMap::new(),
-            added_chunks: Vec::new(),
-            updated_chunks: Vec::new(),
+            regions: Vec::new()
         };
 
-        let world_width_chunks = (WORLD_WIDTH / CHUNK_SIZE as i32) + 1;
-        let world_height_chunks = (WORLD_HEIGHT / CHUNK_SIZE as i32) + 1;
-
-        for y in 0..world_height_chunks {
-            for x in 0..world_width_chunks {
-                let chunkpos = GridVec::new(x, y);
-                created.add_chunk(chunkpos);
-            }
-        }
+        created.regions.push(Region::new(GridVec::new(0, 0)));
 
         return created;
     }
 
     pub fn contains(&self, pos: GridVec) -> bool {
-        let chunk_pos = World::get_chunkpos(pos);
-        return self.chunks.contains_key(&chunk_pos.combined());
+        for reg in self.regions.iter() {
+            if reg.contains_point(&pos) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    pub(crate) fn get_chunk_mut(&mut self, chunkpos: &GridVec) -> Option<&mut Box<Chunk>> {
+        for reg in self.regions.iter_mut() {
+            if reg.contains_point(chunkpos) {
+                return reg.get_chunk_mut(chunkpos);
+            }
+        }
+        return None;
     }
 
     pub fn get_chunk(&self, chunkpos: &GridVec) -> Option<&Box<Chunk>> {
-        self.chunks.get(&chunkpos.combined())
-    }
-
-    fn add_chunk(&mut self, chunkpos: GridVec) {
-        let mut added = Box::new(Chunk::new(chunkpos));
-
-        for (_pos, chunk) in self.chunks.iter_mut() {
-            chunk.check_add_neighbor(&mut added);
+        for reg in self.regions.iter() {
+            if reg.contains_point(chunkpos) {
+                return reg.get_chunk(chunkpos);
+            }
         }
-
-        self.chunks.insert(chunkpos.combined(), added);
-        self.added_chunks.push(chunkpos);
+        return None;
     }
 
     pub fn get_added_chunks(&mut self) -> Vec<GridVec> {
-        let set = self.added_chunks.clone();
-        self.added_chunks.clear();
+        let mut set = Vec::new();
+        for reg in self.regions.iter_mut() {
+            set.append(&mut reg.get_added_chunks());
+        }
         return set;
     }
 
     pub fn get_updated_chunks(&mut self) -> Vec<GridVec> {
-        let set = self.updated_chunks.clone();
-        self.updated_chunks.clear();
+        let mut set = Vec::new();
+        for reg in self.regions.iter_mut() {
+            set.append(&mut &mut reg.get_updated_chunks());
+        }
         return set;
     }
 
-    fn get_chunkpos(pos: GridVec) -> GridVec {
+    pub(crate) fn get_chunkpos(pos: &GridVec) -> GridVec {
         GridVec::new(pos.x / CHUNK_SIZE as i32, pos.y / CHUNK_SIZE as i32)
     }
 
-    fn get_chunklocal(pos: GridVec) -> GridVec {
+    pub(crate) fn get_chunklocal(pos: GridVec) -> GridVec {
         let mut modded = GridVec::new(pos.x % CHUNK_SIZE as i32, pos.y % CHUNK_SIZE as i32);
         if modded.x < 0 { 
             modded.x += CHUNK_SIZE as i32; 
@@ -85,14 +83,14 @@ impl World {
         return modded;
     }
 
-    pub fn _get_particle(&self, pos: GridVec) -> Particle {
-        if !self.contains(pos) {
-            return Particle::new(ParticleType::Boundary);
+    pub fn get_particle(&self, pos: GridVec) -> Particle {
+        for reg in self.regions.iter() {
+            if reg.contains_point(&pos) {
+                return reg.get_particle(pos);
+            }
         }
 
-        let chunk_pos = World::get_chunkpos(pos);
-        let chunklocal = World::get_chunklocal(pos);
-        return self.chunks.get(&chunk_pos.combined()).unwrap().get_particle(chunklocal.x as u8, chunklocal.y as u8);
+        return Particle::new(ParticleType::Boundary);
     }
 
     pub fn replace_particle(&mut self, pos: GridVec, new_val: Particle) {
@@ -100,9 +98,9 @@ impl World {
             return;
         }
 
-        let chunk_pos = World::get_chunkpos(pos);
+        let chunkpos = World::get_chunkpos(&pos);
         let chunklocal = World::get_chunklocal(pos);
-        self.chunks.get_mut(&chunk_pos.combined()).unwrap().set_particle(chunklocal.x as u8, chunklocal.y as u8, new_val);
+        self.get_chunk_mut(&chunkpos).unwrap().set_particle(chunklocal.x as u8, chunklocal.y as u8, new_val);
     }
 
     pub fn add_particle(&mut self, pos: GridVec, new_val: Particle) {
@@ -110,9 +108,9 @@ impl World {
             return;
         }
 
-        let chunk_pos = World::get_chunkpos(pos);
+        let chunkpos = World::get_chunkpos(&pos);
         let chunklocal = World::get_chunklocal(pos);
-        self.chunks.get_mut(&chunk_pos.combined()).unwrap().add_particle(chunklocal.x as u8, chunklocal.y as u8, new_val);
+        self.get_chunk_mut(&chunkpos).unwrap().add_particle(chunklocal.x as u8, chunklocal.y as u8, new_val);
     }
 
     pub fn clear_circle(&mut self, pos: GridVec, radius: i32) {
@@ -133,76 +131,19 @@ impl World {
         }
     }
 
-    pub fn render(&self, screen_bounds: &GridBounds, draw_debug: bool) -> Vec<Particle> {
-        let mut outbuffer = Vec::new();
-        let top_right = screen_bounds.top_right();
-        let bottom_left = screen_bounds.bottom_left();
-        let buffer_height = top_right.y - bottom_left.y;
-        let buffer_width = top_right.x - bottom_left.x;
-
-        outbuffer.resize(buffer_height as usize * buffer_width as usize, Particle::new(ParticleType::Boundary));
-
-        self.chunks.iter().for_each(|(chunk_pos_combined, chunk)| {
-            let chunk_pos = GridVec::decombined(*chunk_pos_combined);
-            let chunk_bottom_left = chunk_pos * CHUNK_SIZE as i32;
-            let chunk_bounds = GridBounds::new_from_corner(chunk_bottom_left, GridVec::new(CHUNK_SIZE as i32, CHUNK_SIZE as i32));
-
-            if let Some(overlap) = screen_bounds.intersect(chunk_bounds) {
-                for overlap_pos in overlap.iter() {
-                    let chunk_local = World::get_chunklocal(overlap_pos);
-                    let buffer_local = overlap_pos - bottom_left;
-                    let buffer_index = (buffer_local.x + (buffer_width * buffer_local.y)) as usize;
-
-                    let mut write_val = chunk.get_particle(chunk_local.x as u8, chunk_local.y as u8);
-
-                    if draw_debug {
-                        if chunk_local.x == 0 || chunk_local.y == 0 || chunk_local.x as u8 == CHUNK_SIZE - 1 || chunk_local.y as u8 == CHUNK_SIZE - 1 {
-                            write_val = Particle::new(ParticleType::Boundary);
-                        }
-                        if let Some(updated_bounds) = chunk.updated_last_frame {
-                            if updated_bounds.is_boundary(chunk_local){
-                                write_val = Particle::new(ParticleType::Dirty);
-                            }
-                        }
-                    }
-
-                    outbuffer[buffer_index] = write_val;
-                }
-            }
-        });
-
-        return outbuffer;
-    }
-
     pub fn update(&mut self) -> u64 {
         let updated_count = AtomicU64::new(0);
 
-        self.chunks.iter().for_each(|(pos, chunk)| {
-            if chunk.dirty.is_some() || chunk.updated_last_frame.is_some()  {
-                self.updated_chunks.push(GridVec::decombined(*pos));
-            }
-        });
-
-        self.chunks.par_iter_mut().for_each(|(_pos, chunk)| {
-            chunk.commit_updates();
+        self.regions.par_iter_mut().for_each(|region| {
+            region.commit_updates();
         });
 
         let shift = (rand::thread_rng().next_u32() % 4) as i32;
-
-        for i in 0..4{
-            
-            let x_mod = (i + shift) % 2;
-            let y_mod = ((i + shift) / 2) % 2; 
-
-            self.chunks.par_iter_mut().for_each(|(pos, chunk)| {
-                let chunk_pos = GridVec::decombined(*pos);
-
-                if chunk_pos.x % 2 == x_mod && chunk_pos.y % 2 == y_mod {
-                    if chunk.update_this_frame.is_some() || chunk.updated_last_frame.is_some() { 
-                        updated_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                        chunk.update(); 
-                    }
-                }
+        for i in 0..4 {
+            let phase = i + shift;
+            self.regions.par_iter_mut().for_each(|region| {
+                let region_updates = region.update(phase);
+                updated_count.fetch_add(region_updates, std::sync::atomic::Ordering::Relaxed); 
             });
         }
         

--- a/sandworld/src/sandworld.rs
+++ b/sandworld/src/sandworld.rs
@@ -268,12 +268,6 @@ impl World {
 
         let chunk_updates = updated_chunk_count.load(std::sync::atomic::Ordering::Relaxed);
 
-        // println!("Estimated {} chunk updates, actual was {} - a factor of {}", 
-        //     estimated_chunk_updates, 
-        //     chunk_updates,
-        //     estimated_chunk_updates as f32 / chunk_updates as f32
-        // );
-        
         WorldUpdateStats {
             chunk_updates,
             loaded_regions: self.regions.len(),

--- a/sandworld/src/sandworld.rs
+++ b/sandworld/src/sandworld.rs
@@ -24,6 +24,14 @@ impl World {
         created.regions.push(Region::new(GridVec::new(1, 0)));
         created.regions.push(Region::new(GridVec::new(-1, 0)));
 
+        created.regions.push(Region::new(GridVec::new(0, -1)));
+        created.regions.push(Region::new(GridVec::new(1, -1)));
+        created.regions.push(Region::new(GridVec::new(-1, -1)));
+
+        created.regions.push(Region::new(GridVec::new(0, 1)));
+        created.regions.push(Region::new(GridVec::new(1, 1)));
+        created.regions.push(Region::new(GridVec::new(-1, 1)));
+
         return created;
     }
 

--- a/sandworld/src/sandworld.rs
+++ b/sandworld/src/sandworld.rs
@@ -32,6 +32,8 @@ impl World {
         created.add_region(GridVec::new(1, 1));
         created.add_region(GridVec::new(-1, 1));
 
+        created.remove_region(GridVec::new(0, 0));
+
         return created;
     }
 
@@ -43,6 +45,25 @@ impl World {
         }
 
         self.regions.push(added);
+    }
+
+    fn remove_region(&mut self, regpos: GridVec) {
+        if let Some(index) = self.get_region_index(regpos) {
+            self.regions.remove(index);
+
+            for region in self.regions.iter_mut() {
+                region.check_remove_neighbor(&regpos);
+            }
+        }
+    }
+
+    fn get_region_index(&self, regpos: GridVec) -> Option<usize> {
+        for i in 0..self.regions.len() {
+            if self.regions[i].position == regpos {
+                return Some(i);
+            }
+        }
+        return None;
     }
 
     pub fn contains(&self, pos: GridVec) -> bool {

--- a/sandworld/src/sandworld.rs
+++ b/sandworld/src/sandworld.rs
@@ -10,8 +10,15 @@ use crate::region::*;
 pub const WORLD_WIDTH: i32 = 1440;
 pub const WORLD_HEIGHT: i32 = 960;
 
+pub const TRUE_REGION_SIZE: usize = REGION_SIZE as usize * CHUNK_SIZE as usize;
+
 pub struct World {
     regions: Vec<Region>
+}
+
+pub struct WorldUpdateStats {
+    pub chunk_updates: u64,
+    pub loaded_regions: usize,
 }
 
 impl World {
@@ -33,7 +40,7 @@ impl World {
         created.add_region(GridVec::new(-1, 1));
 
         created.remove_region(GridVec::new(0, 0));
-
+        
         return created;
     }
 
@@ -180,7 +187,7 @@ impl World {
         }
     }
 
-    pub fn update(&mut self) -> u64 {
+    pub fn update(&mut self) -> WorldUpdateStats {
         let updated_count = AtomicU64::new(0);
 
         self.regions.par_iter_mut().for_each(|region| {
@@ -196,6 +203,9 @@ impl World {
             });
         }
         
-        updated_count.load(std::sync::atomic::Ordering::Relaxed)
+        WorldUpdateStats {
+            chunk_updates: updated_count.load(std::sync::atomic::Ordering::Relaxed),
+            loaded_regions: self.regions.len(),
+        }
     }
 }

--- a/sandworld/src/sandworld.rs
+++ b/sandworld/src/sandworld.rs
@@ -23,23 +23,23 @@ pub struct WorldUpdateStats {
 
 impl World {
     pub fn new() -> Self {
-        let mut created: World = World {
+        let created: World = World {
             regions: Vec::new()
         };
 
-        created.add_region(GridVec::new(0, 0));
-        created.add_region(GridVec::new(1, 0));
-        created.add_region(GridVec::new(-1, 0));
+        // created.add_region(GridVec::new(0, 0));
+        // created.add_region(GridVec::new(1, 0));
+        // created.add_region(GridVec::new(-1, 0));
 
-        created.add_region(GridVec::new(0, -1));
-        created.add_region(GridVec::new(1, -1));
-        created.add_region(GridVec::new(-1, -1));
+        // created.add_region(GridVec::new(0, -1));
+        // created.add_region(GridVec::new(1, -1));
+        // created.add_region(GridVec::new(-1, -1));
 
-        created.add_region(GridVec::new(0, 1));
-        created.add_region(GridVec::new(1, 1));
-        created.add_region(GridVec::new(-1, 1));
+        // created.add_region(GridVec::new(0, 1));
+        // created.add_region(GridVec::new(1, 1));
+        // created.add_region(GridVec::new(-1, 1));
 
-        created.remove_region(GridVec::new(0, 0));
+        // created.remove_region(GridVec::new(0, 0));
         
         return created;
     }
@@ -52,6 +52,8 @@ impl World {
         }
 
         self.regions.push(added);
+
+        println!("Added region {}", regpos);
     }
 
     fn remove_region(&mut self, regpos: GridVec) {
@@ -71,6 +73,17 @@ impl World {
             }
         }
         return None;
+    }
+
+    fn get_regionpos_for_chunkpos(chunkpos: &GridVec) -> GridVec {
+        let mut modpos = chunkpos.clone();
+        if modpos.x < 0 {
+            modpos.x -= REGION_SIZE as i32 - 1;
+        }
+        if modpos.y < 0 {
+            modpos.y -= REGION_SIZE as i32 - 1;
+        }
+        GridVec::new(modpos.x / REGION_SIZE as i32, modpos.y / REGION_SIZE as i32)
     }
 
     pub fn contains(&self, pos: GridVec) -> bool {
@@ -150,7 +163,9 @@ impl World {
 
     pub fn replace_particle(&mut self, pos: GridVec, new_val: Particle) {
         if !self.contains(pos) {
-            return;
+            let chunkpos = World::get_chunkpos(&pos);
+            let regpos = World::get_regionpos_for_chunkpos(&chunkpos);
+            self.add_region(regpos);
         }
 
         let chunkpos = World::get_chunkpos(&pos);
@@ -160,7 +175,9 @@ impl World {
 
     pub fn add_particle(&mut self, pos: GridVec, new_val: Particle) {
         if !self.contains(pos) {
-            return;
+            let chunkpos = World::get_chunkpos(&pos);
+            let regpos = World::get_regionpos_for_chunkpos(&chunkpos);
+            self.add_region(regpos);
         }
 
         let chunkpos = World::get_chunkpos(&pos);

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -41,7 +41,7 @@ fn camera_movement(
     let move_speed = 128.;
     let zoom_speed = 0.5;
 
-    let max_zoom = 10.;
+    let max_zoom = 2.;
     let min_zoom = 0.1;
 
     if keys.pressed(KeyCode::D) || keys.pressed(KeyCode::Right) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ fn main(){
             title: "Project Sandbox - Bevy".to_string(),
             width: 500.,
             height: 300.,
-            present_mode: PresentMode::AutoVsync,
+            present_mode: PresentMode::Immediate,
             ..default()
         })
         .insert_resource(ClearColor(Color::rgb(0.04, 0.04, 0.04)))

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use bevy::{prelude::*, render::texture::ImageSettings, window::PresentMode };
 mod sandsim;
 mod camera;
 mod ui;
+mod perf;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[derive(SystemLabel)]
@@ -22,6 +23,7 @@ fn main(){
         .add_plugin(crate::sandsim::SandSimulationPlugin)
         .add_plugin(crate::camera::CameraPlugin)
         .add_plugin(crate::ui::UiPlugin)
+        .add_plugin(crate::perf::PerfControlPlugin)
         .insert_resource(WindowDescriptor {
             title: "Project Sandbox - Bevy".to_string(),
             width: 500.,

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ fn main(){
             title: "Project Sandbox - Bevy".to_string(),
             width: 500.,
             height: 300.,
-            present_mode: PresentMode::Immediate,
+            present_mode: PresentMode::AutoVsync,
             ..default()
         })
         .insert_resource(ClearColor(Color::rgb(0.04, 0.04, 0.04)))

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -1,0 +1,36 @@
+use std::collections::VecDeque;
+
+use bevy::prelude::*;
+
+pub struct FrameTimes {
+    recent: VecDeque<f64>,
+    pub current_avg: f64, 
+}
+
+pub struct PerfSettings {
+    pub target_frame_rate: u32
+}
+
+pub struct PerfControlPlugin;
+
+impl Plugin for PerfControlPlugin {
+    fn build(&self, app: &mut App) {
+        app
+            .insert_resource(FrameTimes { recent: VecDeque::new(), current_avg: 0. })
+            .insert_resource(PerfSettings { target_frame_rate: 60 })
+            .add_system(frame_timing)
+        ;
+    }
+}
+
+fn frame_timing(
+    time: Res<Time>,
+    mut timing_data: ResMut<FrameTimes>,
+) {
+    timing_data.recent.push_back(time.delta_seconds_f64());
+    if timing_data.recent.len() > 64 {
+        timing_data.recent.pop_front();
+    }
+
+    timing_data.current_avg = timing_data.recent.iter().fold(0., |total, val| { total + val }) / (timing_data.recent.len() as f64);
+}

--- a/src/sandsim.rs
+++ b/src/sandsim.rs
@@ -76,7 +76,7 @@ fn create_spawned_chunks(
     let added_chunks = world.get_added_chunks();
     for chunkpos in added_chunks {
         if let Some(chunk) = world.get_chunk(&chunkpos) {
-            println!("New chunk at {} - created an entity to render it", chunkpos);
+            //println!("New chunk at {} - created an entity to render it", chunkpos);
             let image = render_chunk_texture(chunk.as_ref(), &draw_options);
             let image_handle = images.add(image);
 

--- a/src/sandsim.rs
+++ b/src/sandsim.rs
@@ -76,7 +76,7 @@ fn create_spawned_chunks(
     let added_chunks = world.get_added_chunks();
     for chunkpos in added_chunks {
         if let Some(chunk) = world.get_chunk(&chunkpos) {
-            //println!("New chunk at {} - created an entity to render it", chunkpos);
+            println!("New chunk at {} - created an entity to render it", chunkpos);
             let image = render_chunk_texture(chunk.as_ref(), &draw_options);
             let image_handle = images.add(image);
 

--- a/src/sandsim.rs
+++ b/src/sandsim.rs
@@ -1,5 +1,5 @@
 use bevy::{prelude::*, render::{render_resource::{Extent3d, TextureFormat}, camera::{RenderTarget}} };
-use gridmath::GridVec;
+use gridmath::{GridVec, GridBounds};
 
 pub struct SandSimulationPlugin;
 
@@ -127,9 +127,20 @@ fn update_chunk_textures(
     }
 }
 
-fn sand_update(mut world: ResMut<sandworld::World>, mut world_stats: ResMut<WorldStats>) {
-    let stats = world.update();  
+fn sand_update(
+    mut world: ResMut<sandworld::World>, 
+    mut world_stats: ResMut<WorldStats>,
+    cam_query: Query<(&OrthographicProjection, &GlobalTransform)>,
+) {
+    let (ortho, cam_transform) = cam_query.single();
+    let bounds = GridBounds::new_from_extents(
+        GridVec::new(ortho.left as i32, ortho.bottom as i32) + GridVec::new(cam_transform.translation().x as i32, cam_transform.translation().y as i32), 
+        GridVec::new(ortho.right as i32, ortho.top as i32) + GridVec::new(cam_transform.translation().x as i32, cam_transform.translation().y as i32),
+    );
+    let stats = world.update(bounds);  
     world_stats.update_stats = Some(stats);  
+
+    //println!("camera bounds {}", bounds);
 }
 
 fn world_interact(

--- a/src/sandsim.rs
+++ b/src/sandsim.rs
@@ -92,7 +92,6 @@ fn create_spawned_chunks(
     let added_chunks = world.get_added_chunks();
     for chunkpos in added_chunks {
         if let Some(chunk) = world.get_chunk(&chunkpos) {
-            //println!("New chunk at {} - created an entity to render it", chunkpos);
             let image = render_chunk_texture(chunk.as_ref(), &draw_options);
             let image_handle = images.add(image);
 
@@ -123,6 +122,7 @@ fn update_chunk_textures(
         return;
     }
 
+    // TODO: look into only doing this work for visible chunks and doing catchup for chunks that become visible later
     for chunk_comp in chunk_query.iter() {
         if draw_options.force_redraw_all || updated_chunks.contains(&chunk_comp.chunk_pos) {
             if let Some(chunk) = world.get_chunk(&chunk_comp.chunk_pos) {
@@ -167,8 +167,6 @@ fn sand_update(
         world_stats.sand_update_time.pop_front();
     }
     world_stats.update_stats = Some(stats);  
-
-    //println!("camera bounds {}", bounds);
 }
 
 fn world_interact(
@@ -208,17 +206,14 @@ fn world_interact(
             // reduce it to a 2D value
             let world_pos: Vec2 = world_pos.truncate();
 
-            //println!("World coords: {}/{}", world_pos.x as i32, world_pos.y as i32);
-
             let gridpos = GridVec::new(world_pos.x as i32, world_pos.y as i32);
-            //if sand.contains(gridpos) {
-                if buttons.pressed(MouseButton::Left){
-                    sand.place_circle(gridpos, brush_options.radius, sandworld::Particle::new(brush_options.material), false);
-                }
-                else if buttons.pressed(MouseButton::Right) {
-                    sand.place_circle(gridpos, 10, sandworld::Particle::new(sandworld::ParticleType::Air), true);
-                }
-            //}
+
+            if buttons.pressed(MouseButton::Left){
+                sand.place_circle(gridpos, brush_options.radius, sandworld::Particle::new(brush_options.material), false);
+            }
+            else if buttons.pressed(MouseButton::Right) {
+                sand.place_circle(gridpos, 10, sandworld::Particle::new(sandworld::ParticleType::Air), true);
+            }
         }
     }
 }

--- a/src/sandsim.rs
+++ b/src/sandsim.rs
@@ -3,6 +3,8 @@ use bevy::{prelude::*, render::{render_resource::{Extent3d, TextureFormat}, came
 use gridmath::{GridVec, GridBounds};
 use sandworld::CHUNK_SIZE;
 
+use crate::camera::cam_bounds;
+
 pub struct SandSimulationPlugin;
 
 impl Plugin for SandSimulationPlugin {
@@ -121,10 +123,7 @@ fn cull_hidden_chunks(
     cam_query: Query<(&OrthographicProjection, &GlobalTransform)>,
 ) {
     let (ortho, cam_transform) = cam_query.single();
-    let bounds = GridBounds::new_from_extents(
-        GridVec::new(ortho.left as i32, ortho.bottom as i32) + GridVec::new(cam_transform.translation().x as i32, cam_transform.translation().y as i32), 
-        GridVec::new(ortho.right as i32, ortho.top as i32) + GridVec::new(cam_transform.translation().x as i32, cam_transform.translation().y as i32),
-    );
+    let bounds = cam_bounds(ortho, cam_transform);
 
     chunk_query.par_for_each_mut(16, |(chunk, mut vis)| {
         let chunk_bounds = GridBounds::new_from_corner(chunk.chunk_pos * (CHUNK_SIZE as i32), GridVec { x: CHUNK_SIZE as i32, y: CHUNK_SIZE as i32 });
@@ -191,10 +190,7 @@ fn sand_update(
     }
 
     let (ortho, cam_transform) = cam_query.single();
-    let bounds = GridBounds::new_from_extents(
-        GridVec::new(ortho.left as i32, ortho.bottom as i32) + GridVec::new(cam_transform.translation().x as i32, cam_transform.translation().y as i32), 
-        GridVec::new(ortho.right as i32, ortho.top as i32) + GridVec::new(cam_transform.translation().x as i32, cam_transform.translation().y as i32),
-    );
+    let bounds = cam_bounds(ortho, cam_transform);
 
     let update_start = std::time::Instant::now();
     let stats = world.update(bounds, target_chunk_updates);

--- a/src/sandsim.rs
+++ b/src/sandsim.rs
@@ -9,11 +9,15 @@ impl Plugin for SandSimulationPlugin {
         .insert_resource(DrawOptions {
             update_bounds: false,
             chunk_bounds: false,
+            world_stats: false,
             force_redraw_all: false,
         })
         .insert_resource(BrushOptions {
             material: sandworld::ParticleType::Sand,
             radius: 10,
+        })
+        .insert_resource(WorldStats {
+            update_stats: None,
         })
         .add_system(create_spawned_chunks.label(crate::UpdateStages::WorldUpdate))
         .add_system(sand_update.label(crate::UpdateStages::WorldUpdate))
@@ -32,6 +36,7 @@ struct Chunk {
 pub struct DrawOptions {
     pub update_bounds: bool,
     pub chunk_bounds: bool,
+    pub world_stats: bool,
     pub force_redraw_all: bool,
 }
 
@@ -40,6 +45,9 @@ pub struct BrushOptions {
     pub radius: i32,
 }
 
+pub struct WorldStats {
+    pub update_stats: Option<sandworld::WorldUpdateStats>,
+}
 
 fn draw_mode_controls(
     mut draw_options: ResMut<DrawOptions>,
@@ -54,6 +62,9 @@ fn draw_mode_controls(
     if keys.just_pressed(KeyCode::F3) {
         draw_options.update_bounds = !draw_options.update_bounds;
         draw_options.force_redraw_all = true;
+    }
+    if keys.just_pressed(KeyCode::F4) {
+        draw_options.world_stats = !draw_options.world_stats;
     }
 }
 
@@ -116,8 +127,9 @@ fn update_chunk_textures(
     }
 }
 
-fn sand_update(mut world: ResMut<sandworld::World>) {
-    world.update();    
+fn sand_update(mut world: ResMut<sandworld::World>, mut world_stats: ResMut<WorldStats>) {
+    let stats = world.update();  
+    world_stats.update_stats = Some(stats);  
 }
 
 fn world_interact(

--- a/src/sandsim.rs
+++ b/src/sandsim.rs
@@ -172,14 +172,14 @@ fn world_interact(
             //println!("World coords: {}/{}", world_pos.x as i32, world_pos.y as i32);
 
             let gridpos = GridVec::new(world_pos.x as i32, world_pos.y as i32);
-            if sand.contains(gridpos) {
+            //if sand.contains(gridpos) {
                 if buttons.pressed(MouseButton::Left){
                     sand.place_circle(gridpos, brush_options.radius, sandworld::Particle::new(brush_options.material), false);
                 }
                 else if buttons.pressed(MouseButton::Right) {
                     sand.place_circle(gridpos, 10, sandworld::Particle::new(sandworld::ParticleType::Air), true);
                 }
-            }
+            //}
         }
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -75,6 +75,14 @@ fn spawn_performance_info_text(
                     font_size: 20.0,
                     color: Color::rgb(0.9, 0.9, 0.6),
                 }
+            },
+            TextSection {
+                value: "\nAvg render time per chunk".to_string(),
+                style: TextStyle {
+                    font: asset_server.load("fonts/FiraMono-Medium.ttf"),
+                    font_size: 20.0,
+                    color: Color::rgb(0.9, 0.9, 0.6),
+                }
             }
         ]
     ).with_style(Style {
@@ -101,7 +109,17 @@ fn update_performance_text(
             text.sections[1].value = format!("\nLoaded Regions: {}", world_stats.loaded_regions);
             text.sections[2].value = format!("\nRegion Updates: {}", world_stats.region_updates);
             text.sections[3].value = format!("\nChunk Updates [Target]: {} [{}]", world_stats.chunk_updates, stats.target_chunk_updates);
-            
+
+            let mut texture_update_time_avg = 0.;
+            let mut texture_update_per_chunk_avg = 0.;
+            for (time, count) in &stats.chunk_texture_update_time {
+                texture_update_time_avg += time;
+                texture_update_per_chunk_avg += time / (*count as f64);
+            }
+            texture_update_time_avg = texture_update_time_avg / (stats.chunk_texture_update_time.len() as f64);
+            texture_update_per_chunk_avg = texture_update_per_chunk_avg / (stats.chunk_texture_update_time.len() as f64);
+
+            text.sections[5].value = format!("\nTex Update time:  {:.2}ms - Avg time per chunk: {:.3}ms", texture_update_time_avg * 1000., texture_update_per_chunk_avg * 1000.);
         }
 
         let mut chunk_updates_per_second_avg = 0.;
@@ -113,7 +131,7 @@ fn update_performance_text(
         chunk_updates_per_second_avg = chunk_updates_per_second_avg / (stats.sand_update_time.len() as f64);
         total_sand_update_second_avg = total_sand_update_second_avg / (stats.sand_update_time.len() as f64);
 
-        text.sections[4].value = format!("\nSand update time {:.2}ms - Avg time per chunk: {:.3}ms", total_sand_update_second_avg * 1000., 1000. / chunk_updates_per_second_avg);
+        text.sections[4].value = format!("\nSand update time: {:.2}ms - Avg time per chunk: {:.3}ms", total_sand_update_second_avg * 1000., 1000. / chunk_updates_per_second_avg);
     }
     else {
         vis.is_visible = false;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -89,19 +89,18 @@ fn update_performance_text(
     mut text_query: Query<(&PerformanceReadout, &mut Text, &mut Visibility)>,
     stats: Res<crate::sandsim::WorldStats>,
     draw_options: Res<crate::sandsim::DrawOptions>,
-    time: Res<Time>,
+    frame_times: Res<crate::perf::FrameTimes>,
 ) {
     let (_, mut text, mut vis) = text_query.single_mut();
     if draw_options.world_stats {
         vis.is_visible = true;
 
-
-        text.sections[0].value = format!("FPS: {} ({:.1}ms)", (1. / time.delta_seconds_f64()).round() as u32, time.delta_seconds_f64() * 1000.);
+        text.sections[0].value = format!("FPS: {} ({:.1}ms)", (1. / frame_times.current_avg).round() as u32, frame_times.current_avg * 1000.);
 
         if let Some(world_stats) = &stats.update_stats {
             text.sections[1].value = format!("\nLoaded Regions: {}", world_stats.loaded_regions);
             text.sections[2].value = format!("\nRegion Updates: {}", world_stats.region_updates);
-            text.sections[3].value = format!("\nChunk Updates: {}", world_stats.chunk_updates);
+            text.sections[3].value = format!("\nChunk Updates [Target]: {} [{}]", world_stats.chunk_updates, stats.target_chunk_updates);
             
         }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -45,6 +45,14 @@ fn spawn_performance_info_text(
                 }
             },
             TextSection {
+                value: "\nUpdated Regions: 000".to_string(),
+                style: TextStyle {
+                    font: asset_server.load("fonts/FiraMono-Medium.ttf"),
+                    font_size: 30.0,
+                    color: Color::rgb(0.9, 0.9, 0.9),
+                }
+            },
+            TextSection {
                 value: "\nChunk Updates: 000".to_string(),
                 style: TextStyle {
                     font: asset_server.load("fonts/FiraMono-Medium.ttf"),
@@ -71,7 +79,8 @@ fn update_performance_text(
         vis.is_visible = true;
         if let Some(world_stats) = &stats.update_stats {
             text.sections[0].value = format!("Loaded Regions: {}", world_stats.loaded_regions);
-            text.sections[1].value = format!("\nChunk Updates: {}", world_stats.chunk_updates);
+            text.sections[1].value = format!("\nRegion Updates: {}", world_stats.region_updates);
+            text.sections[2].value = format!("\nChunk Updates: {}", world_stats.chunk_updates);
         }
     }
     else {


### PR DESCRIPTION
Regions are groups of 16x16 chunks. They can be dynamically added to the world as needed at runtime. Different regions also can update at different frequencies depending on how much performance headroom is available. 