### PR TITLE
added move subsets

### DIFF
--- a/sandworld/src/chunk.rs
+++ b/sandworld/src/chunk.rs
@@ -415,12 +415,15 @@ impl Chunk {
                     let available_moves = Particle::get_possible_moves(cur_part.particle_type);
                     if available_moves.len() > 0 {
                         let mut possible_moves = Vec::<GridVec>::new();
-                        let can_replace_water = Particle::can_replace_water(cur_part.particle_type);
-                        
-                        for vec in available_moves {
-                            if self.test_vec(x, y, vec.x as i8, vec.y as i8, can_replace_water) {
-                                possible_moves.push(vec.clone());
+                        for move_set in available_moves {
+                            let can_replace_water = Particle::can_replace_water(cur_part.particle_type);
+                            for vec in move_set {
+                                if self.test_vec(x, y, vec.x as i8, vec.y as i8, can_replace_water) {
+                                    possible_moves.push(vec.clone());
+                                }
                             }
+                            
+                            if !possible_moves.is_empty() { break; }
                         }
                         
                         if possible_moves.len() > 0 {

--- a/sandworld/src/particle.rs
+++ b/sandworld/src/particle.rs
@@ -23,11 +23,11 @@ impl Particle {
         Particle{particle_type, updated_this_frame: false}
     }
 
-    pub fn get_possible_moves(particle_type: ParticleType) -> Vec::<GridVec> {
+    pub fn get_possible_moves(particle_type: ParticleType) -> Vec::<Vec::<GridVec>> {
         match particle_type {
-            ParticleType::Sand => vec![GridVec{x: 1, y: -1}, GridVec{x: -1, y: -1}, GridVec{x: 0, y: -1}],
-            ParticleType::Water => vec![GridVec{x: 1, y: -1}, GridVec{x: 0, y: -1}, GridVec{x: -1, y: -1}, GridVec{x: 1, y: 0}, GridVec{x: -1, y: 0} ],
-            _ => Vec::<GridVec>::new(),
+            ParticleType::Sand => vec![vec![GridVec{x: 0, y: -1}], vec![GridVec{x: 1, y: -1}, GridVec{x: -1, y: -1}]],
+            ParticleType::Water => vec![vec![GridVec{x: 1, y: -1}, GridVec{x: 0, y: -1}, GridVec{x: -1, y: -1}, GridVec{x: 1, y: 0}, GridVec{x: -1, y: 0} ]],
+            _ => Vec::<Vec::<GridVec>>::new(),
         }
     }
 


### PR DESCRIPTION
Adds the ability for particle types to present their movement options in priority subsets.

If no moves from the n-th group are available, the (n+1)-th group is tried. This allows for more sand-like sand that will always fall straight down if possible, then will spread once landed (since the fall is in the first group, it will always be chosen first if it can).