### PR TITLE
Add world generation and additional materials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2686,6 +2686,7 @@ dependencies = [
  "bevy",
  "gridmath",
  "noise",
+ "rand 0.8.5",
  "sandworld",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.6",
  "once_cell",
  "version_check",
 ]
@@ -787,7 +787,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7473635355a99fcf7181091a2ac11df03561706b1696cb0cc72e4ddd010571"
 dependencies = [
  "ahash",
- "getrandom",
+ "getrandom 0.2.6",
  "hashbrown",
  "instant",
  "tracing",
@@ -1435,6 +1435,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
@@ -1597,7 +1608,7 @@ dependencies = [
 name = "gridmath"
 version = "0.1.0"
 dependencies = [
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2118,6 +2129,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "noise"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ba869e17168793186c10ca82c7079a4ffdeac4f1a7d9e755b9491c028180e40"
+dependencies = [
+ "num-traits",
+ "rand 0.7.3",
+ "rand_xorshift",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2422,13 +2444,36 @@ checksum = "17fd96390ed3feda12e1dfe2645ed587e0bea749e319333f104a33ff62f77a0b"
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -2438,7 +2483,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -2447,7 +2501,25 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.6",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -2613,6 +2685,7 @@ version = "0.1.0"
 dependencies = [
  "bevy",
  "gridmath",
+ "noise",
  "sandworld",
 ]
 
@@ -2621,7 +2694,7 @@ name = "sandworld"
 version = "0.1.0"
 dependencies = [
  "gridmath",
- "rand",
+ "rand 0.8.5",
  "rayon",
 ]
 
@@ -3012,7 +3085,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.6",
  "serde",
 ]
 
@@ -3050,6 +3123,12 @@ dependencies = [
  "winapi",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ gridmath = { path = "gridmath" }
 sandworld = { path = "sandworld" }
 bevy = "0.9"
 noise = "0.8"
+rand = "0.8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2021"
 gridmath = { path = "gridmath" }
 sandworld = { path = "sandworld" }
 bevy = "0.9"
+noise = "0.8"

--- a/gridmath/src/gridvec.rs
+++ b/gridmath/src/gridvec.rs
@@ -22,6 +22,10 @@ impl GridVec {
         (self.x - other.x).abs() + (self.y - other.y).abs()
     }
 
+    pub fn sq_distance(&self, other: GridVec) -> i32 {
+        (self.x - other.x).pow(2) + (self.y - other.y).pow(2)
+    }
+    
     pub fn manhattan_length(&self) -> i32 {
         self.x.abs() + self.y.abs()
     }

--- a/sandworld/src/chunk.rs
+++ b/sandworld/src/chunk.rs
@@ -1,8 +1,10 @@
 pub const CHUNK_SIZE: u8 = 64;
+use std::sync::Arc;
+
 use gridmath::*;
 use rand::{Rng, rngs::ThreadRng};
 use crate::region::REGION_SIZE;
-use crate::particle::*;
+use crate::{particle::*, WorldGenerator};
 
 pub struct Chunk {
     pub position: GridVec,
@@ -102,7 +104,7 @@ impl Chunk {
         return created;
     }
     
-    pub fn generate(position: GridVec, generator: fn(GridVec) -> Particle) -> Self{
+    pub fn generate(position: GridVec, generator: &Arc<dyn WorldGenerator + Send + Sync>) -> Self{
         let mut chunk = Chunk::new(position);
         
         for y in 0..CHUNK_SIZE {
@@ -111,7 +113,7 @@ impl Chunk {
                     x as i32 + (CHUNK_SIZE as i32 * chunk.position.x),
                      y as i32 + (CHUNK_SIZE as i32 * chunk.position.y));
                 
-                chunk.set_particle(x, y, generator(worldpos));
+                chunk.set_particle(x, y, generator.get_particle(worldpos));
             }
         }
         

--- a/sandworld/src/chunk.rs
+++ b/sandworld/src/chunk.rs
@@ -528,8 +528,14 @@ impl Chunk {
                         || cur_part.particle_type == ParticleType::Gravel
                         || cur_part.particle_type == ParticleType::Sand {
                         let adj_lava = self.count_neighbors_of_type(x as i16, y as i16, ParticleType::Lava);
-                        if adj_lava > 4 {
-                            if rng.gen_bool(0.25 * (adj_lava - 4) as f64) {
+                        
+                        let start_melt = match cur_part.particle_type {
+                            ParticleType::Stone => 4,
+                            _=> 3,
+                        };
+                        
+                        if adj_lava > start_melt {
+                            if rng.gen_bool((1. / (8 - start_melt) as f64) * (adj_lava - start_melt) as f64) {
                                 self.set_particle(x, y, Particle::new(ParticleType::Lava));                            
                             }
                         }

--- a/sandworld/src/chunk.rs
+++ b/sandworld/src/chunk.rs
@@ -503,6 +503,12 @@ impl Chunk {
                         if y > 0 { self.add_particle(x, y - 1, Particle::new(ParticleType::Water)); }
                         if y < CHUNK_SIZE - 1 { self.add_particle(x, y + 1, Particle::new(ParticleType::Water)); }
                     }
+                    if cur_part.particle_type == ParticleType::LSource {
+                        if x > 0 { self.add_particle(x - 1, y, Particle::new(ParticleType::Lava)); }
+                        if x < CHUNK_SIZE - 1 { self.add_particle(x + 1, y, Particle::new(ParticleType::Lava)); }
+                        if y > 0 { self.add_particle(x, y - 1, Particle::new(ParticleType::Lava)); }
+                        if y < CHUNK_SIZE - 1 { self.add_particle(x, y + 1, Particle::new(ParticleType::Lava)); }
+                    }
                     else if cur_part.particle_type == ParticleType::Steam {
                         let non_air = 8 - self.count_neighbors_of_type(x as i16 , y as i16, ParticleType::Air);
                         if rng.gen_bool(0.005 * (non_air + 1) as f64) {

--- a/sandworld/src/chunk.rs
+++ b/sandworld/src/chunk.rs
@@ -102,6 +102,22 @@ impl Chunk {
         return created;
     }
     
+    pub fn generate(position: GridVec, generator: fn(GridVec) -> Particle) -> Self{
+        let mut chunk = Chunk::new(position);
+        
+        for y in 0..CHUNK_SIZE {
+            for x in 0..CHUNK_SIZE {
+                let worldpos = GridVec::new(
+                    x as i32 + (CHUNK_SIZE as i32 * chunk.position.x),
+                     y as i32 + (CHUNK_SIZE as i32 * chunk.position.y));
+                
+                chunk.set_particle(x, y, generator(worldpos));
+            }
+        }
+        
+        chunk
+    }
+    
     fn get_index_in_chunk(x: u8, y: u8) -> usize {
         return y as usize * CHUNK_SIZE as usize + x as usize;
     }
@@ -252,7 +268,10 @@ impl Chunk {
                 return priority_movement; 
             }
             if test_particle.particle_type == ParticleType::Air { return true; }
-            else if replace_water && test_particle.particle_type == ParticleType::Water { return true; }
+            else if replace_water 
+                && (test_particle.particle_type == ParticleType::Water || test_particle.particle_type == ParticleType::Lava) { 
+                    return true; 
+            }
         }
         return false;
     }
@@ -387,6 +406,37 @@ impl Chunk {
             }
         }
     }
+    
+    fn get_local_part(&self, x: i16, y: i16) -> ParticleType {
+        if self.contains(x, y) {
+            self.get_particle(x as u8, y as u8).particle_type
+        }
+        else if let Some(neighbor) = self.get_neighbor( Chunk::get_oob_direction(x, y) ) {
+            let dir = Chunk::get_oob_direction(x, y);
+            let adjusted_x = x - (dir.x as i16 * CHUNK_SIZE as i16);
+            let adjusted_y = y - (dir.y as i16 * CHUNK_SIZE as i16);
+            
+            unsafe {
+                (*neighbor).get_particle(adjusted_x as u8, adjusted_y as u8).particle_type
+            }
+        }
+        else {
+            ParticleType::Air
+        }
+    }
+    
+    fn count_neighbors_of_type(&self, x: i16, y: i16, search: ParticleType) -> u8 {
+        let mut count = 0;
+        if self.get_local_part(x + 1, y + 1) == search { count += 1; }
+        if self.get_local_part(x, y + 1) == search { count += 1; }
+        if self.get_local_part(x - 1, y + 1) == search { count += 1; }
+        if self.get_local_part(x + 1, y) == search { count += 1; }
+        if self.get_local_part(x - 1, y) == search { count += 1; }
+        if self.get_local_part(x + 1, y - 1) == search { count += 1; }
+        if self.get_local_part(x, y - 1) == search { count += 1; }
+        if self.get_local_part(x - 1, y - 1) == search { count += 1; }
+        return count;
+    }
 
     fn try_erode(&mut self, rng: &mut ThreadRng, x: i16, y: i16, vel: &GridVec) {
         if self.contains(x, y) {
@@ -396,14 +446,27 @@ impl Chunk {
                     ParticleType::Sand => {
                         let next_x = x as i16 + vel.x as i16;
                         let next_y = y as i16 + vel.y as i16;
-                        if self.contains(next_x, next_y) && rng.gen_bool(0.2) {
+                        if self.contains(next_x, next_y) && rng.gen_bool(0.1) {
                             self.set_particle(x as u8, y as u8, self.get_particle(next_x as u8, next_y as u8));
                             self.set_particle(next_x as u8, next_y as u8, part);
                         }
                     }
-                    ParticleType::Stone => {
-                        if rng.gen_bool(0.01) {
+                    ParticleType::Gravel => {
+                        if rng.gen_bool(0.002) {
                             self.set_particle(x as u8, y as u8, Particle { particle_type: ParticleType::Sand, updated_this_frame: true })
+                        }
+                        else {
+                            let next_x = x as i16 + vel.x as i16;
+                            let next_y = y as i16 + vel.y as i16;
+                            if self.contains(next_x, next_y) && rng.gen_bool(0.001) {
+                                self.set_particle(x as u8, y as u8, self.get_particle(next_x as u8, next_y as u8));
+                                self.set_particle(next_x as u8, next_y as u8, part);
+                            }
+                        }
+                    }
+                    ParticleType::Stone => {
+                        if rng.gen_bool(0.002) {
+                            self.set_particle(x as u8, y as u8, Particle { particle_type: ParticleType::Gravel, updated_this_frame: true });
                         }
                     }
                     _ => ()
@@ -414,6 +477,7 @@ impl Chunk {
             let dir = Chunk::get_oob_direction(x, y);
             let adjusted_x = x - (dir.x as i16 * CHUNK_SIZE as i16);
             let adjusted_y = y - (dir.y as i16 * CHUNK_SIZE as i16);
+            
             unsafe {
                 (*neighbor).try_erode(rng, adjusted_x, adjusted_y, vel);
             }
@@ -436,6 +500,39 @@ impl Chunk {
                         if x < CHUNK_SIZE - 1 { self.add_particle(x + 1, y, Particle::new(ParticleType::Water)); }
                         if y > 0 { self.add_particle(x, y - 1, Particle::new(ParticleType::Water)); }
                         if y < CHUNK_SIZE - 1 { self.add_particle(x, y + 1, Particle::new(ParticleType::Water)); }
+                    }
+                    else if cur_part.particle_type == ParticleType::Steam {
+                        let non_air = 8 - self.count_neighbors_of_type(x as i16 , y as i16, ParticleType::Air);
+                        if rng.gen_bool(0.005 * (non_air + 1) as f64) {
+                            self.set_particle(x, y, Particle::new(ParticleType::Water));
+                        }
+                    }
+                    else if cur_part.particle_type == ParticleType::Lava {
+                        let adj_water = self.count_neighbors_of_type(x as i16, y as i16, ParticleType::Water);
+                        let adj_stone = self.count_neighbors_of_type(x as i16, y as i16, ParticleType::Stone);
+                        let adj_lava = self.count_neighbors_of_type(x as i16, y as i16, ParticleType::Lava);
+                        if rng.gen_bool(0.04 * adj_water as f64) {
+                            self.set_particle(x, y, Particle::new(ParticleType::Stone));                            
+                        }
+                        if adj_stone > adj_lava && rng.gen_bool(0.02 * (adj_stone - adj_lava) as f64){
+                            self.set_particle(x, y, Particle::new(ParticleType::Stone));                            
+                        }
+                    }
+                    else if cur_part.particle_type == ParticleType::Water {
+                        let adj_lava = self.count_neighbors_of_type(x as i16, y as i16, ParticleType::Lava);
+                        if rng.gen_bool(0.1 * adj_lava as f64) {
+                            self.set_particle(x, y, Particle::new(ParticleType::Steam));                            
+                        }
+                    }
+                    else if cur_part.particle_type == ParticleType::Stone 
+                        || cur_part.particle_type == ParticleType::Gravel
+                        || cur_part.particle_type == ParticleType::Sand {
+                        let adj_lava = self.count_neighbors_of_type(x as i16, y as i16, ParticleType::Lava);
+                        if adj_lava > 4 {
+                            if rng.gen_bool(0.25 * (adj_lava - 4) as f64) {
+                                self.set_particle(x, y, Particle::new(ParticleType::Lava));                            
+                            }
+                        }
                     }
                     
                     let available_moves = Particle::get_possible_moves(cur_part.particle_type);

--- a/sandworld/src/particle.rs
+++ b/sandworld/src/particle.rs
@@ -6,6 +6,9 @@ pub enum ParticleType {
     Sand,
     Water,
     Stone,
+    Gravel,
+    Steam,
+    Lava,
     Source,
     Boundary,
     RegionBoundary,
@@ -26,13 +29,26 @@ impl Particle {
     pub fn get_possible_moves(particle_type: ParticleType) -> Vec::<Vec::<GridVec>> {
         match particle_type {
             ParticleType::Sand => vec![
-                vec![GridVec{x: 0, y: -1}, GridVec{x: 0, y: -2}, GridVec{x: 0, y: -3}], 
+                vec![GridVec{x: 0, y: -1}, GridVec{x: 0, y: -2}], 
+                vec![GridVec{x: -1, y: -1}, GridVec{x: 1, y: -1}, GridVec{x: 2, y: -1}, GridVec{x: -2, y: -1}],
+                ],
+            ParticleType::Gravel => vec![
+                vec![GridVec{x: 0, y: -4}, GridVec{x: 0, y: -2}, GridVec{x: 0, y: -3}],                 
+                vec![GridVec{x: 0, y: -1}], 
                 vec![GridVec{x: 1, y: -1}, GridVec{x: -1, y: -1}],
                 ],
             ParticleType::Water => vec![
                 vec![GridVec{x: 1, y: -2}, GridVec{x: -1, y: -2}, GridVec{x: 0, y: -2}, GridVec{x: 1, y: -1}, GridVec{x: -1, y: -1}, GridVec{x: 0, y: -1}],
                 vec![GridVec{x: 1, y: 0}, GridVec{x: -1, y: 0}, GridVec{x: 2, y: -1}, GridVec{x: -2, y: -1}, GridVec{x: 2, y: 0}, GridVec{x: -2, y: 0}, GridVec{x: 3, y: -1}, GridVec{x: -3, y: -1}],
                 vec![GridVec{x: 3, y: 0}, GridVec{x: -3, y: 0}, GridVec{x: 5, y: -1}, GridVec{x: -5, y: -1}, GridVec{x: 5, y: 0}, GridVec{x: -5, y: 0}, GridVec{x: 5, y: -1}, GridVec{x: -5, y: -1}],
+                ],
+            ParticleType::Steam => vec![
+                vec![GridVec{x: 1, y: 2}, GridVec{x: -1, y: 2}, GridVec{x: 0, y: 2}, GridVec{x: 1, y: 1}, GridVec{x: -1, y: 1}, GridVec{x: 0, y: 1}],
+                vec![GridVec{x: 1, y: 0}, GridVec{x: -1, y: 0}, GridVec{x: 1, y: -1}, GridVec{x: -1, y: -1}, GridVec{x: 2, y: 0}, GridVec{x: -2, y: 0}, GridVec{x: 2, y: 1}, GridVec{x: 2, y: 11}],
+                ],
+            ParticleType::Lava => vec![
+                vec![GridVec{x: 1, y: -2}, GridVec{x: -1, y: -2}, GridVec{x: 0, y: -2}, GridVec{x: 0, y: -1}],
+                vec![GridVec{x: 1, y: -1}, GridVec{x: -1, y: -1}, GridVec{x: 1, y: 0}, GridVec{x: -1, y: 0}, GridVec{x: 2, y: -1}, GridVec{x: -2, y: -1}, GridVec{x: 2, y: 0}, GridVec{x: -2, y: 0}, GridVec{x: 3, y: -1}, GridVec{x: -3, y: -1}],
                 ],
             _ => Vec::<Vec::<GridVec>>::new(),
         }
@@ -41,6 +57,8 @@ impl Particle {
     pub fn can_replace_water(particle_type: ParticleType) -> bool {
         match particle_type {
             ParticleType::Sand => true,
+            ParticleType::Gravel => true,
+            ParticleType::Steam => true,
             _ => false,
         }
     }
@@ -54,8 +72,11 @@ impl Default for Particle {
 pub fn get_color_for_type(particle_type: ParticleType) -> [u8; 4] {
     match particle_type {
         ParticleType::Sand => [0xdc, 0xcd, 0x79, 0xff],
-        ParticleType::Water => [0x56, 0x9c, 0xd6, 0xff],
-        ParticleType::Stone => [0xd4, 0xd4, 0xd4, 0xff],
+        ParticleType::Water => [0x6d, 0x95, 0xc9, 0xff], // #6d95c9
+        ParticleType::Gravel => [0xa9, 0xa3, 0xb5, 0xff], // #a9a3b5
+        ParticleType::Stone => [0x6b, 0x6f, 0x75, 0xff], //#6b6f75
+        ParticleType::Steam => [0xe6, 0xec, 0xf0, 0xff], //#e6ecf0
+        ParticleType::Lava => [0xf0, 0x95, 0x16, 0xff], //#f09516
         ParticleType::Air => [0x1e, 0x1e, 0x1e, 0xff],
         ParticleType::Source => [0xf7, 0xdf, 0x00, 0xff],
         ParticleType::Dirty => [0xFF, 0x00, 0xFF, 0xff],

--- a/sandworld/src/particle.rs
+++ b/sandworld/src/particle.rs
@@ -10,6 +10,7 @@ pub enum ParticleType {
     Steam,
     Lava,
     Source,
+    LSource,
     Boundary,
     RegionBoundary,
     Dirty,
@@ -79,6 +80,7 @@ pub fn get_color_for_type(particle_type: ParticleType) -> [u8; 4] {
         ParticleType::Lava => [0xf0, 0x95, 0x16, 0xff], //#f09516
         ParticleType::Air => [0x1e, 0x1e, 0x1e, 0xff],
         ParticleType::Source => [0xf7, 0xdf, 0x00, 0xff],
+        ParticleType::LSource => [0xff, 0xdf, 0x00, 0xff],
         ParticleType::Dirty => [0xFF, 0x00, 0xFF, 0xff],
         ParticleType::RegionBoundary => [0xFF, 0xFF, 0x00, 0xFF],
         _ => [0x00, 0x00, 0x00, 0xff],

--- a/sandworld/src/region.rs
+++ b/sandworld/src/region.rs
@@ -16,10 +16,11 @@ pub struct Region {
     // Chunks that have been updated since last polled
     updated_chunks: Vec<GridVec>,
     pub update_priority: u64,
+    generator: fn(GridVec)->Particle,
 }
 
 impl Region {
-    pub fn new(position: GridVec) -> Self {
+    pub fn new(position: GridVec, generator: fn(GridVec)->Particle) -> Self {
         let mut reg = Region {
             position,
             staleness: 0,
@@ -27,7 +28,8 @@ impl Region {
             chunks: vec![],
             added_chunks: vec![],
             updated_chunks: vec![],
-            update_priority: 0
+            update_priority: 0,
+            generator
         };
 
         for y in 0..REGION_SIZE as i32 {
@@ -40,7 +42,7 @@ impl Region {
     }
 
     fn add_chunk(&mut self, chunkpos: GridVec) {
-        let mut added = Box::new(Chunk::new(chunkpos));
+        let mut added = Box::new(Chunk::generate(chunkpos, self.generator));
 
         for chunk in self.chunks.iter_mut() {
             chunk.check_add_neighbor(&mut added);

--- a/sandworld/src/region.rs
+++ b/sandworld/src/region.rs
@@ -19,8 +19,6 @@ pub struct Region {
     generator: Arc<dyn WorldGenerator + Send + Sync>,
 }
 
-unsafe impl Send for Region {}
-
 impl Region {
     pub fn new(position: GridVec, generator: Arc<dyn WorldGenerator + Send + Sync>) -> Self {
         let mut reg = Region {

--- a/sandworld/src/sandworld.rs
+++ b/sandworld/src/sandworld.rs
@@ -13,7 +13,8 @@ pub const WORLD_HEIGHT: i32 = 960;
 pub const TRUE_REGION_SIZE: usize = REGION_SIZE as usize * CHUNK_SIZE as usize;
 
 pub struct World {
-    regions: Vec<Region>
+    regions: Vec<Region>,
+    generator: fn(GridVec)->Particle,    
 }
 
 pub struct WorldUpdateStats {
@@ -23,16 +24,17 @@ pub struct WorldUpdateStats {
 }
 
 impl World {
-    pub fn new() -> Self {
+    pub fn new(generator: fn(GridVec)->Particle) -> Self {
         let created: World = World {
-            regions: Vec::new()
+            regions: Vec::new(),
+            generator,
         };
 
         return created;
     }
 
     fn add_region(&mut self, regpos: GridVec) {
-        let mut added = Region::new(regpos);
+        let mut added = Region::new(regpos, self.generator);
 
         for region in self.regions.iter_mut() {
             region.check_add_neighbor(&mut added);
@@ -199,8 +201,10 @@ impl World {
 
         for y in bottom..top {
             for x in left..right {
-                if replace { self.replace_particle(GridVec{x, y}, new_val.clone()); }
-                else { self.add_particle(GridVec{x, y}, new_val.clone()); }
+                if pos.sq_distance(GridVec{x, y}) < radius.pow(2) {
+                    if replace { self.replace_particle(GridVec{x, y}, new_val.clone()); }
+                    else { self.add_particle(GridVec{x, y}, new_val.clone()); }
+                }
             }
         }
     }

--- a/sandworld/src/sandworld.rs
+++ b/sandworld/src/sandworld.rs
@@ -14,7 +14,7 @@ pub const TRUE_REGION_SIZE: usize = REGION_SIZE as usize * CHUNK_SIZE as usize;
 
 pub struct World {
     regions: Vec<Region>,
-    generator: fn(GridVec)->Particle,    
+    generator: fn(GridVec)->Particle,
 }
 
 pub struct WorldUpdateStats {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod sandsim;
 mod camera;
 mod ui;
 mod perf;
+mod worldgen;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[derive(SystemLabel)]

--- a/src/sandsim.rs
+++ b/src/sandsim.rs
@@ -11,7 +11,7 @@ pub struct SandSimulationPlugin;
 impl Plugin for SandSimulationPlugin {
     fn build(&self, app: &mut App) {
         let mut rng = rand::thread_rng();
-        let seed: u32 = 0;// rng.gen();
+        let seed: u32 = rng.gen();
         
         println!("Seed: {}", seed);
         

--- a/src/sandsim.rs
+++ b/src/sandsim.rs
@@ -9,7 +9,7 @@ pub struct SandSimulationPlugin;
 
 impl Plugin for SandSimulationPlugin {
     fn build(&self, app: &mut App) {
-        app.insert_resource(Sandworld {world: sandworld::World::new() })
+        app.insert_resource(Sandworld {world: sandworld::World::new(crate::worldgen::basic_perlin) })
         .insert_resource(DrawOptions {
             update_bounds: false,
             chunk_bounds: false,

--- a/src/sandsim.rs
+++ b/src/sandsim.rs
@@ -1,4 +1,4 @@
-use std::collections::VecDeque;
+use std::{collections::VecDeque, sync::Arc};
 use bevy::{prelude::*, render::{render_resource::{Extent3d, TextureFormat}, camera::{RenderTarget}} };
 use gridmath::{GridVec, GridBounds};
 use sandworld::CHUNK_SIZE;
@@ -9,7 +9,12 @@ pub struct SandSimulationPlugin;
 
 impl Plugin for SandSimulationPlugin {
     fn build(&self, app: &mut App) {
-        app.insert_resource(Sandworld {world: sandworld::World::new(crate::worldgen::basic_perlin) })
+        app.insert_resource(Sandworld {
+            world: sandworld::World::new(
+                Arc::new(
+                    crate::worldgen::BasicPerlin::new(0)
+                )
+        ) })
         .insert_resource(DrawOptions {
             update_bounds: false,
             chunk_bounds: false,

--- a/src/sandsim.rs
+++ b/src/sandsim.rs
@@ -11,14 +11,14 @@ pub struct SandSimulationPlugin;
 impl Plugin for SandSimulationPlugin {
     fn build(&self, app: &mut App) {
         let mut rng = rand::thread_rng();
-        let seed = rng.gen();
+        let seed: u32 = 0;// rng.gen();
         
         println!("Seed: {}", seed);
         
         app.insert_resource(Sandworld {
             world: sandworld::World::new(
                 Arc::new(
-                    crate::worldgen::LayeredPerlin::new(seed, 0.003, 0.01, 0.0001)
+                    crate::worldgen::LayeredPerlin::new(seed, 0.003, 0.01, 2.)
                 )
         ) })
         .insert_resource(DrawOptions {

--- a/src/sandsim.rs
+++ b/src/sandsim.rs
@@ -2,6 +2,7 @@ use std::{collections::VecDeque, sync::Arc};
 use bevy::{prelude::*, render::{render_resource::{Extent3d, TextureFormat}, camera::{RenderTarget}} };
 use gridmath::{GridVec, GridBounds};
 use sandworld::CHUNK_SIZE;
+use rand::{Rng, rngs::ThreadRng};
 
 use crate::camera::cam_bounds;
 
@@ -9,10 +10,15 @@ pub struct SandSimulationPlugin;
 
 impl Plugin for SandSimulationPlugin {
     fn build(&self, app: &mut App) {
+        let mut rng = rand::thread_rng();
+        let seed = rng.gen();
+        
+        println!("Seed: {}", seed);
+        
         app.insert_resource(Sandworld {
             world: sandworld::World::new(
                 Arc::new(
-                    crate::worldgen::BasicPerlin::new(0)
+                    crate::worldgen::LayeredPerlin::new(seed, 0.003, 0.01, 0.0001)
                 )
         ) })
         .insert_resource(DrawOptions {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -190,7 +190,8 @@ fn setup_buttons(mut commands: Commands, asset_server: Res<AssetServer>) {
     spawn_tool_selector_button(&mut commands, &asset_server, "Water", ParticleType::Water, 10);
     spawn_tool_selector_button(&mut commands, &asset_server, "Lava", ParticleType::Lava, 10);
     spawn_tool_selector_button(&mut commands, &asset_server, "Steam", ParticleType::Steam, 10);
-    spawn_tool_selector_button(&mut commands, &asset_server, "Source", ParticleType::Source, 1);
+    spawn_tool_selector_button(&mut commands, &asset_server, "WSource", ParticleType::Source, 1);
+    spawn_tool_selector_button(&mut commands, &asset_server, "LSource", ParticleType::LSource, 1);
 }
 
 fn button_system(

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -185,8 +185,11 @@ fn spawn_tool_selector_button(
 
 fn setup_buttons(mut commands: Commands, asset_server: Res<AssetServer>) {
     spawn_tool_selector_button(&mut commands, &asset_server, "Sand", ParticleType::Sand, 10);
-    spawn_tool_selector_button(&mut commands, &asset_server, "Stone", ParticleType::Stone, 10);
+    spawn_tool_selector_button(&mut commands, &asset_server, "Gravel", ParticleType::Gravel, 10);
+    spawn_tool_selector_button(&mut commands, &asset_server, "Stone", ParticleType::Stone, 20);
     spawn_tool_selector_button(&mut commands, &asset_server, "Water", ParticleType::Water, 10);
+    spawn_tool_selector_button(&mut commands, &asset_server, "Lava", ParticleType::Lava, 10);
+    spawn_tool_selector_button(&mut commands, &asset_server, "Steam", ParticleType::Steam, 10);
     spawn_tool_selector_button(&mut commands, &asset_server, "Source", ParticleType::Source, 1);
 }
 

--- a/src/worldgen.rs
+++ b/src/worldgen.rs
@@ -16,7 +16,7 @@ pub fn basic_simplex(worldpos: GridVec) -> Particle {
     let sample_pos = [worldpos.x as f64 * 0.01, worldpos.y as f64 * 0.01];
     let noise_val = Simplex::new(0).get(sample_pos);
     
-    Particle::new(if noise_val < 0.1 { ParticleType::Air } else { ParticleType::Stone })    
+    Particle::new(if noise_val < 0.05 { ParticleType::Air } else { ParticleType::Stone })    
 }
 
 pub fn basic_perlin(worldpos: GridVec) -> Particle {

--- a/src/worldgen.rs
+++ b/src/worldgen.rs
@@ -22,7 +22,7 @@ pub struct LayeredPerlin {
     noise: Perlin,
     scale_macro: f64,
     scale_detail: f64,
-    scale_cave_density: f64,
+    cave_noisiness: f64,
 }
 
 impl WorldGenerator for Blankworld {
@@ -76,12 +76,12 @@ impl WorldGenerator for BasicPerlin {
 }
 
 impl LayeredPerlin {
-    pub fn new(seed: u32, scale_macro: f64, scale_detail: f64, scale_cave_density: f64) -> Self {
+    pub fn new(seed: u32, scale_macro: f64, scale_detail: f64, cave_noisiness: f64) -> Self {
         LayeredPerlin {
             noise: Perlin::new(seed),
             scale_macro,
             scale_detail,
-            scale_cave_density,
+            cave_noisiness,
         }
     }
 }
@@ -95,7 +95,7 @@ impl WorldGenerator for LayeredPerlin {
         let detail_noise_val = self.noise.get(detail_sample_pos);
         //let cave_sample_noise_val = self.noise.get(cave_sample_pos);
         
-        Particle::new(if detail_noise_val < macro_noise_val * 3.0 { 
+        Particle::new(if detail_noise_val < macro_noise_val * self.cave_noisiness { 
             ParticleType::Air
         } 
         else { 

--- a/src/worldgen.rs
+++ b/src/worldgen.rs
@@ -19,7 +19,7 @@ pub struct BasicPerlin {
 }
 
 impl WorldGenerator for Blankworld {
-    fn get_particle(&self, world_pos: GridVec) -> Particle {
+    fn get_particle(&self, _world_pos: GridVec) -> Particle {
         Particle::new(ParticleType::Air)
     }
 }

--- a/src/worldgen.rs
+++ b/src/worldgen.rs
@@ -1,0 +1,28 @@
+use std::sync::{Arc, Mutex};
+
+use noise::{Simplex, NoiseFn, Perlin};
+use sandworld::{Particle, ParticleType};
+use gridmath::GridVec;
+
+pub fn blankworld_generator(_worldpos: GridVec) -> Particle {
+    Particle::new(ParticleType::Air)
+}
+
+pub fn stone_plain(worldpos: GridVec) -> Particle {
+    Particle::new(if worldpos.y > 0 { ParticleType::Air } else { ParticleType::Stone })
+}
+
+pub fn basic_simplex(worldpos: GridVec) -> Particle {
+    let sample_pos = [worldpos.x as f64 * 0.01, worldpos.y as f64 * 0.01];
+    let noise_val = Simplex::new(0).get(sample_pos);
+    
+    Particle::new(if noise_val < 0.1 { ParticleType::Air } else { ParticleType::Stone })    
+}
+
+pub fn basic_perlin(worldpos: GridVec) -> Particle {
+    let noise = Perlin::new(0);
+    let sample_pos = [worldpos.x as f64 * 0.01, worldpos.y as f64 * 0.01];
+    let noise_val = noise.get(sample_pos);
+        
+    Particle::new(if noise_val < 0.05 { ParticleType::Air } else { ParticleType::Stone })   
+}


### PR DESCRIPTION
Adds additional lava, gravel, and steam materials. And some behaviors.
Adds a WorldGenerator trait that users can implement to define world 
generation behaviors to use when generating new chunks

﻿- generation start
- added forgotten worldgen file
- variable melt
- made world generators be objects
- cleanup
- caves?
- tuned generation values
