### PR TITLE
Can replace for not just water

### DIFF
--- a/sandworld/src/chunk.rs
+++ b/sandworld/src/chunk.rs
@@ -522,17 +522,17 @@ impl Chunk {
                         let adj_water = self.count_neighbors_of_type(x as i16, y as i16, ParticleType::Water);
                         let adj_stone = self.count_neighbors_of_type(x as i16, y as i16, ParticleType::Stone);
                         let adj_lava = self.count_neighbors_of_type(x as i16, y as i16, ParticleType::Lava);
-                        if rng.gen_bool(0.1 * adj_water as f64) {
+                        if adj_water > 1 && rng.gen_bool(0.1 * (adj_water + adj_stone / 2) as f64) {
                             self.set_particle(x, y, Particle::new(ParticleType::Stone));                            
                         }
-                        if adj_stone > adj_lava && rng.gen_bool(0.02 * (adj_stone - adj_lava) as f64){
+                        else if adj_stone > adj_lava && rng.gen_bool(0.02 * (adj_stone - adj_lava) as f64){
                             self.set_particle(x, y, Particle::new(ParticleType::Stone));                            
                         }
                     }
                     else if cur_part.particle_type == ParticleType::Water {
                         let adj_lava = self.count_neighbors_of_type(x as i16, y as i16, ParticleType::Lava);
                         let adj_ice = self.count_neighbors_of_type(x as i16, y as i16, ParticleType::Ice);
-                        if rng.gen_bool(0.1 * adj_lava as f64) {
+                        if rng.gen_bool(0.01 * adj_lava as f64) {
                             self.set_particle(x, y, Particle::new(ParticleType::Steam));                            
                         }
                         else if adj_ice > 3 && rng.gen_bool(0.01 * (adj_ice - 3) as f64) {

--- a/sandworld/src/chunk.rs
+++ b/sandworld/src/chunk.rs
@@ -263,32 +263,30 @@ impl Chunk {
         }
     }
     
-    fn get_part_can_move(&self, test_pos_x: i16, test_pos_y: i16, priority_movement: bool, replace_water: bool) -> bool {
+    fn get_part_can_move(&self, test_pos_x: i16, test_pos_y: i16, priority_movement: bool, test_type: ParticleType) -> bool {
         if let Some(test_particle) = self.get_test_particle(test_pos_x, test_pos_y) {
             if test_particle.updated_this_frame { 
                 // Need to allow things to fall into spaces otherwise weird air bubbles are allowed to persist
                 return priority_movement; 
             }
             if test_particle.particle_type == ParticleType::Air { return true; }
-            else if replace_water 
-                && (test_particle.particle_type == ParticleType::Water || test_particle.particle_type == ParticleType::Lava) { 
-                    return true; 
+            else if Particle::get_can_replace(test_type, test_particle.particle_type) { 
+                return true; 
             }
         }
         return false;
     }
 
-    fn test_vec(&self, base_x: i16, base_y: i16, test_vec_x: i8, test_vec_y: i8, replace_water: bool) -> bool {
+    fn test_vec(&self, base_x: i16, base_y: i16, test_vec_x: i8, test_vec_y: i8, test_type: ParticleType) -> bool {
         if test_vec_x.abs() > 1 || test_vec_y.abs() > 1 {
             // need to step
             let test_pos_x = base_x + test_vec_x.signum() as i16;
             let test_pos_y = base_y + test_vec_y.signum() as i16;
             
-            if self.get_part_can_move(test_pos_x, test_pos_y, test_vec_y < 0, replace_water) {
+            if self.get_part_can_move(test_pos_x, test_pos_y, test_vec_y < 0, test_type) {
                 // Recurse to call next step if this step was clear
                 self.test_vec(test_pos_x, test_pos_y, 
-                    test_vec_x - test_vec_x.signum(), test_vec_y - test_vec_y.signum(), 
-                    replace_water)
+                    test_vec_x - test_vec_x.signum(), test_vec_y - test_vec_y.signum(), test_type)
             }
             else { 
                 false
@@ -298,7 +296,7 @@ impl Chunk {
             let test_pos_x = base_x as i16 + test_vec_x as i16;
             let test_pos_y = base_y as i16 + test_vec_y as i16;
             
-            self.get_part_can_move(test_pos_x, test_pos_y, test_vec_y < 0, replace_water)
+            self.get_part_can_move(test_pos_x, test_pos_y, test_vec_y < 0, test_type)
         }
     }
 
@@ -524,7 +522,7 @@ impl Chunk {
                         let adj_water = self.count_neighbors_of_type(x as i16, y as i16, ParticleType::Water);
                         let adj_stone = self.count_neighbors_of_type(x as i16, y as i16, ParticleType::Stone);
                         let adj_lava = self.count_neighbors_of_type(x as i16, y as i16, ParticleType::Lava);
-                        if rng.gen_bool(0.04 * adj_water as f64) {
+                        if rng.gen_bool(0.1 * adj_water as f64) {
                             self.set_particle(x, y, Particle::new(ParticleType::Stone));                            
                         }
                         if adj_stone > adj_lava && rng.gen_bool(0.02 * (adj_stone - adj_lava) as f64){
@@ -573,9 +571,8 @@ impl Chunk {
                     if available_moves.len() > 0 {
                         let mut possible_moves = Vec::<GridVec>::new();
                         for move_set in available_moves {
-                            let can_replace_water = Particle::can_replace_water(cur_part.particle_type);
                             for vec in move_set {
-                                if self.test_vec(x as i16, y as i16, vec.x as i8, vec.y as i8, can_replace_water) {
+                                if self.test_vec(x as i16, y as i16, vec.x as i8, vec.y as i8, cur_part.particle_type) {
                                     possible_moves.push(vec.clone());
                                 }
                             }

--- a/sandworld/src/particle.rs
+++ b/sandworld/src/particle.rs
@@ -57,16 +57,12 @@ impl Particle {
     }
 
     pub fn get_can_replace(particle_type: ParticleType, replace_type: ParticleType) -> bool {
-        Particle::get_replace_list(particle_type).contains(&replace_type)
-    }
-    
-    pub fn get_replace_list(particle_type: ParticleType) -> Vec<ParticleType> {
         match particle_type {
-            ParticleType::Sand => vec![ParticleType::Water, ParticleType::Steam],
-            ParticleType::Gravel => vec![ParticleType::Water, ParticleType::Steam, ParticleType::Lava],
-            ParticleType::Steam => vec![ParticleType::Water, ParticleType::Lava],
-            ParticleType::Lava => vec![ParticleType::Water, ParticleType::Steam, ParticleType::Sand],
-            _ => vec![]
+            ParticleType::Sand => [ParticleType::Water, ParticleType::Steam].contains(&replace_type),
+            ParticleType::Gravel => [ParticleType::Water, ParticleType::Steam, ParticleType::Lava].contains(&replace_type),
+            ParticleType::Steam => [ParticleType::Water, ParticleType::Lava].contains(&replace_type),
+            ParticleType::Lava => [ParticleType::Water, ParticleType::Steam, ParticleType::Sand].contains(&replace_type),
+            _ => false
         }
     }
 }

--- a/sandworld/src/particle.rs
+++ b/sandworld/src/particle.rs
@@ -56,12 +56,17 @@ impl Particle {
         }
     }
 
-    pub fn can_replace_water(particle_type: ParticleType) -> bool {
+    pub fn get_can_replace(particle_type: ParticleType, replace_type: ParticleType) -> bool {
+        Particle::get_replace_list(particle_type).contains(&replace_type)
+    }
+    
+    pub fn get_replace_list(particle_type: ParticleType) -> Vec<ParticleType> {
         match particle_type {
-            ParticleType::Sand => true,
-            ParticleType::Gravel => true,
-            ParticleType::Steam => true,
-            _ => false,
+            ParticleType::Sand => vec![ParticleType::Water, ParticleType::Steam],
+            ParticleType::Gravel => vec![ParticleType::Water, ParticleType::Steam, ParticleType::Lava],
+            ParticleType::Steam => vec![ParticleType::Water, ParticleType::Lava],
+            ParticleType::Lava => vec![ParticleType::Water, ParticleType::Steam, ParticleType::Sand],
+            _ => vec![]
         }
     }
 }


### PR DESCRIPTION
Replace the old can_replace_water with a more generic version that allows each particle type to specify which other types it can replace. This essentially means that anything can float/sink on/in anything else it wants to.

The new behaviours that this comes with required some tweaking of lava/steam rules to make things behave sensibly again since lava now sinks in water it was producing far too much steam on the way down before solidifying.