### PR TITLE
fixed diagonal multi-movement

### DIFF
--- a/sandworld/src/chunk.rs
+++ b/sandworld/src/chunk.rs
@@ -288,6 +288,19 @@ impl Chunk {
                 self.test_vec(test_pos_x, test_pos_y, 
                     test_vec_x - test_vec_x.signum(), test_vec_y - test_vec_y.signum(), test_type)
             }
+            else if test_vec_x != 0 && test_vec_y != 0 {
+                if test_vec_x.abs() > test_vec_y.abs() && self.get_part_can_move(test_pos_x, base_y, test_vec_y < 0, test_type) {
+                    self.test_vec(test_pos_x, base_y, 
+                        test_vec_x - test_vec_x.signum(), test_vec_y, test_type)
+                }
+                else if  test_vec_x.abs() < test_vec_y.abs() && self.get_part_can_move(base_x, test_pos_y, test_vec_y < 0, test_type) {
+                    self.test_vec(base_x, test_pos_y, 
+                        test_vec_x, test_vec_y - test_vec_y.signum(), test_type)
+                }
+                else {
+                    false
+                }
+            }
             else { 
                 false
             }


### PR DESCRIPTION
Previously rules that tried a longer diagonal if the adjacent diagonal failed would always also fail, as the adjacent diagonal was a required part. Now for longer diagonals, if the diagonal path fails it will also attempt the longer orthogonal path before giving up.