### PR TITLE
Refactor particle update

### DIFF
--- a/gridmath/src/gridvec.rs
+++ b/gridmath/src/gridvec.rs
@@ -56,6 +56,14 @@ impl GridVec {
             (combo & 0x00000000FFFFFFFF) as i32, 
             ((combo & 0xFFFFFFFF00000000) >> 32) as i32)
     }
+    
+    /*
+        Returns vector that is the same as the current one but with at 
+        most length one in any direction
+    */
+    pub fn manhattan_unit(&self) -> GridVec {
+        GridVec { x: self.x.signum(), y: self.y.signum() }
+    }
 }
 
 impl ops::Add<GridVec> for GridVec {

--- a/sandworld/src/chunk.rs
+++ b/sandworld/src/chunk.rs
@@ -265,7 +265,7 @@ impl Chunk {
     
     fn get_part_can_move(&self, test_pos_x: i16, test_pos_y: i16, priority_movement: bool, test_type: ParticleType) -> bool {
         if let Some(test_particle) = self.get_test_particle(test_pos_x, test_pos_y) {
-            if test_particle.updated_this_frame { 
+            if test_particle.updated_this_frame() { 
                 // Need to allow things to fall into spaces otherwise weird air bubbles are allowed to persist
                 return priority_movement || Particle::get_can_replace(test_type, test_particle.particle_type); 
             }
@@ -370,7 +370,7 @@ impl Chunk {
     pub fn set_particle(&mut self, x: u8, y: u8, val: Particle) {
         self.particles[Chunk::get_index_in_chunk(x, y)] = val;
         self.mark_dirty(x as i32, y as i32);
-        self.particles[Chunk::get_index_in_chunk(x, y)].updated_this_frame = true;
+        self.particles[Chunk::get_index_in_chunk(x, y)].set_updated_this_frame(true);
     }
     
     pub fn mark_region_dirty(&mut self, bounds: GridBounds) {
@@ -437,7 +437,7 @@ impl Chunk {
                 let x = point.x as u8;
                 let y = point.y as u8;
                 
-                self.get_particle_mut(x, y).updated_this_frame = false;
+                self.get_particle_mut(x, y).set_updated_this_frame(false);
             }
         }
     }
@@ -507,7 +507,7 @@ impl Chunk {
     fn try_erode(&mut self, rng: &mut ThreadRng, x: i16, y: i16, vel: &GridVec) {
         if self.contains(x, y) {
             let part = self.get_particle(x as u8, y as u8);
-            if !part.updated_this_frame {
+            if !part.updated_this_frame() {
                 match part.particle_type {
                     ParticleType::Sand => {
                         let next_x = x as i16 + vel.x as i16;
@@ -519,7 +519,7 @@ impl Chunk {
                     }
                     ParticleType::Gravel => {
                         if rng.gen_bool(0.002) {
-                            self.set_particle(x as u8, y as u8, Particle { particle_type: ParticleType::Sand, updated_this_frame: true })
+                            self.set_particle(x as u8, y as u8, Particle::new(ParticleType::Sand))
                         }
                         else {
                             let next_x = x as i16 + vel.x as i16;
@@ -532,7 +532,7 @@ impl Chunk {
                     }
                     ParticleType::Stone => {
                         if rng.gen_bool(0.002) {
-                            self.set_particle(x as u8, y as u8, Particle { particle_type: ParticleType::Gravel, updated_this_frame: true });
+                            self.set_particle(x as u8, y as u8, Particle::new(ParticleType::Gravel));
                         }
                     }
                     _ => ()
@@ -619,7 +619,7 @@ impl Chunk {
                 
                 let cur_part = self.get_particle(x, y);
 
-                if !cur_part.updated_this_frame {           
+                if !cur_part.updated_this_frame() {           
                     // Custom Logic
                     let mut move_override = None;
                     let mut destroy_if_not_moved = false;

--- a/sandworld/src/chunk.rs
+++ b/sandworld/src/chunk.rs
@@ -267,7 +267,7 @@ impl Chunk {
         if let Some(test_particle) = self.get_test_particle(test_pos_x, test_pos_y) {
             if test_particle.updated_this_frame { 
                 // Need to allow things to fall into spaces otherwise weird air bubbles are allowed to persist
-                return priority_movement; 
+                return priority_movement || Particle::get_can_replace(test_type, test_particle.particle_type); 
             }
             if test_particle.particle_type == ParticleType::Air { return true; }
             else if Particle::get_can_replace(test_type, test_particle.particle_type) { 

--- a/sandworld/src/chunk.rs
+++ b/sandworld/src/chunk.rs
@@ -405,6 +405,14 @@ impl Chunk {
             self.mark_dirty(x as i32, y as i32);
         }
     }
+    
+        
+    pub(crate) fn try_state_change(&mut self, x: u8, y: u8, temp: i32, rng: &mut ThreadRng) {
+        let cur_part = self.get_particle(x, y);
+        if let Some(new_state) = try_state_change(cur_part.particle_type, temp, rng) {
+            self.set_particle(x, y, Particle::new(new_state));
+        }
+    }
 
     fn _is_border(x: u8, y: u8) -> bool {
         x == 0 || y == 0 || x == CHUNK_SIZE - 1  || y == CHUNK_SIZE - 1

--- a/sandworld/src/particle.rs
+++ b/sandworld/src/particle.rs
@@ -188,7 +188,7 @@ impl CustomUpdateRules {
     
     fn laser_beam_update(_x: u8, _y: u8) -> Vec<ChunkCommand> {
         vec![
-            ChunkCommand::MoveOrDestroy(vec![GridVec{x: 1, y: 0}, GridVec{x: 2, y: 0}]),
+            ChunkCommand::MoveOrDestroy(vec![GridVec{x: 1, y: 0}]),
         ]
     }
     

--- a/sandworld/src/particle.rs
+++ b/sandworld/src/particle.rs
@@ -23,7 +23,11 @@ pub enum ParticleType {
 #[derive(Debug, Copy, Clone)]
 pub struct Particle {
     pub particle_type: ParticleType,
-    pub(crate) updated_this_frame: bool,
+    /*
+        Highest bit is reserved for particle update flag
+        Other bits may be used for custom particle logic
+    */
+    data: u8, 
 }
 
 pub struct StateChange {
@@ -43,7 +47,20 @@ pub(crate) enum ChunkCommand {
 
 impl Particle {
     pub fn new(particle_type: ParticleType) -> Self {
-        Particle{particle_type, updated_this_frame: false}
+        Particle{particle_type, data: 0}
+    }
+    
+    pub(crate) fn updated_this_frame(&self) -> bool {
+        return self.data & (1<<7) != 0
+    }
+    
+    pub(crate) fn set_updated_this_frame(&mut self, val: bool) {
+        if val {
+            self.data |= 1<<7;
+        }
+        else {
+            self.data &= !(1<<7);
+        }
     }
 
     pub fn get_possible_moves(particle_type: ParticleType) -> Vec::<Vec::<GridVec>> {
@@ -88,7 +105,7 @@ impl Particle {
 }
 
 impl Default for Particle {
-    fn default() -> Self { Particle{particle_type: ParticleType::Air, updated_this_frame: false} }
+    fn default() -> Self { Particle::new(ParticleType::Air) }
 }
 
 

--- a/sandworld/src/particle.rs
+++ b/sandworld/src/particle.rs
@@ -120,7 +120,7 @@ pub fn get_heat_for_type(particle_type: ParticleType) -> i32 {
         ParticleType::Sand => 1,
         ParticleType::Gravel => 1,
         ParticleType::Lava => 64,
-        ParticleType::Steam => 8,
+        ParticleType::Steam => 6,
         ParticleType::LaserBeam => 512,
         ParticleType::LaserEmitter => 1024,
         _ => 0,
@@ -132,10 +132,10 @@ pub fn get_state_change_for_type(particle_type: ParticleType) -> StateChange {
         ParticleType::Ice => StateChange{    melt: Some((-28, ParticleType::Water, 0.5)), freeze: None },
         ParticleType::Water => StateChange{  melt: Some((64, ParticleType::Steam, 0.15)), freeze: Some((-40, ParticleType::Ice, 0.15)) },
         ParticleType::Steam => StateChange{  melt: None,                                  freeze: Some((50, ParticleType::Water, 0.05))},
-        ParticleType::Stone => StateChange{  melt: Some((300, ParticleType::Lava, 0.2)),  freeze: None },
+        ParticleType::Stone => StateChange{  melt: Some((300, ParticleType::Lava, 0.05)),  freeze: None },
         ParticleType::Gravel => StateChange{ melt: Some((250, ParticleType::Lava, 0.25)),  freeze: None },
         ParticleType::Sand => StateChange{   melt: Some((180, ParticleType::Lava, 0.5)), freeze: None },
-        ParticleType::Lava => StateChange{   melt: None,                                  freeze: Some((196, ParticleType::Stone, 0.1)) },
+        ParticleType::Lava => StateChange{   melt: None,                                  freeze: Some((255, ParticleType::Stone, 0.1)) },
         _ => StateChange {                   melt: None,                                  freeze: None },
     }
 }
@@ -188,13 +188,13 @@ impl CustomUpdateRules {
     
     fn laser_beam_update(_x: u8, _y: u8) -> Vec<ChunkCommand> {
         vec![
-            ChunkCommand::MoveOrDestroy(vec![GridVec{x: 0, y: 1}, GridVec{x: 0, y: 2}]),
+            ChunkCommand::MoveOrDestroy(vec![GridVec{x: 1, y: 0}, GridVec{x: 2, y: 0}]),
         ]
     }
     
     fn laser_emitter_update(x: u8, y: u8) -> Vec<ChunkCommand> {
         vec![
-            ChunkCommand::Add((GridVec{x: x as i32, y: y as i32 + 1}, ParticleType::LaserBeam)),
+            ChunkCommand::Add((GridVec{x: x as i32 + 1, y: y as i32}, ParticleType::LaserBeam)),
         ]
     }
 } 

--- a/sandworld/src/particle.rs
+++ b/sandworld/src/particle.rs
@@ -12,7 +12,6 @@ pub enum ParticleType {
     Lava,
     Ice,
     Source,
-    LSource,
     LaserBeam,
     LaserEmitter,
     Boundary,
@@ -38,16 +37,25 @@ pub struct StateChange {
 pub(crate) struct CustomUpdateRules;
 
 pub(crate) enum ChunkCommand {
-    Add((GridVec, ParticleType)),
+    Add((GridVec, ParticleType, u8)),
     Move(Vec<GridVec>),
     MoveOrDestroy(Vec<GridVec>),
     Remove,
+    Mutate(ParticleType, u8),
 }
 
 
 impl Particle {
     pub fn new(particle_type: ParticleType) -> Self {
         Particle{particle_type, data: 0}
+    }
+    
+    pub(crate)  fn new_already_updated(particle_type: ParticleType) -> Self {
+        Particle::new_with_data(particle_type, 1 << 7)
+    }
+    
+    pub fn new_with_data(particle_type: ParticleType, particle_data: u8) -> Self {
+        Particle{particle_type, data: particle_data}
     }
     
     pub(crate) fn updated_this_frame(&self) -> bool {
@@ -120,7 +128,6 @@ pub fn get_color_for_type(particle_type: ParticleType) -> [u8; 4] {
         ParticleType::Ice => [0xbf, 0xdb, 0xff, 0xff], //#bfdbff
         ParticleType::Air => [0x1e, 0x1e, 0x1e, 0xff],
         ParticleType::Source => [0xf7, 0xdf, 0x00, 0xff],
-        ParticleType::LSource => [0xff, 0xdf, 0x00, 0xff],
         ParticleType::LaserBeam => [0xff, 0x11, 0x11, 0xff],
         ParticleType::LaserEmitter => [0xff, 0xee, 0xee, 0xff],
         ParticleType::Dirty => [0xFF, 0x00, 0xFF, 0xff],
@@ -151,7 +158,7 @@ pub fn get_state_change_for_type(particle_type: ParticleType) -> StateChange {
         ParticleType::Steam => StateChange{  melt: None,                                  freeze: Some((50, ParticleType::Water, 0.05))},
         ParticleType::Stone => StateChange{  melt: Some((300, ParticleType::Lava, 0.05)),  freeze: None },
         ParticleType::Gravel => StateChange{ melt: Some((250, ParticleType::Lava, 0.25)),  freeze: None },
-        ParticleType::Sand => StateChange{   melt: Some((180, ParticleType::Lava, 0.5)), freeze: None },
+        ParticleType::Sand => StateChange{   melt: Some((230, ParticleType::Lava, 0.5)), freeze: None },
         ParticleType::Lava => StateChange{   melt: None,                                  freeze: Some((255, ParticleType::Stone, 0.1)) },
         _ => StateChange {                   melt: None,                                  freeze: None },
     }
@@ -173,45 +180,80 @@ pub fn try_state_change(particle_type: ParticleType, local_temperature: i32, rng
     return None;
 }
 
-pub(crate) fn update_for_type(particle_type: ParticleType, x: u8, y: u8) -> Option<Vec<ChunkCommand>> {
+pub(crate) fn get_update_fn_for_type(particle_type: ParticleType) -> Option<fn(GridVec, Particle, [ParticleType; 8])->Vec<ChunkCommand>> {
     match particle_type {
-        ParticleType::Source => Some(CustomUpdateRules::water_source_update(x, y)),
-        ParticleType::LSource => Some(CustomUpdateRules::lava_source_update(x, y)),
-        ParticleType::LaserBeam => Some(CustomUpdateRules::laser_beam_update(x, y)),
-        ParticleType::LaserEmitter => Some(CustomUpdateRules::laser_emitter_update(x, y)),
+        ParticleType::Source => Some(CustomUpdateRules::water_source_update),
+        ParticleType::LaserBeam => Some(CustomUpdateRules::laser_beam_update),
+        ParticleType::LaserEmitter => Some(CustomUpdateRules::laser_emitter_update),
         _ => None
     }
 }
 
 
 impl CustomUpdateRules {
-    fn water_source_update(x: u8, y: u8) -> Vec<ChunkCommand> {
-        vec![
-            ChunkCommand::Add((GridVec{x: x as i32 - 1, y: y as i32}, ParticleType::Water)),
-            ChunkCommand::Add((GridVec{x: x as i32 + 1, y: y as i32}, ParticleType::Water)),
-            ChunkCommand::Add((GridVec{x: x as i32, y: y as i32 - 1}, ParticleType::Water)),
-            ChunkCommand::Add((GridVec{x: x as i32, y: y as i32 + 1}, ParticleType::Water)),
+    fn water_source_update(position: GridVec, particle: Particle, neighbors: [ParticleType; 8] ) -> Vec<ChunkCommand> {
+        let data_val = particle.data & !(1<<7);
+        if data_val == 0 {
+            let mut new_val = 0;
+            for part in neighbors {
+                new_val = match  part {
+                    ParticleType::Water => 1,
+                    ParticleType::Lava => 2,
+                    ParticleType::Sand => 3,
+                    ParticleType::Gravel => 4,
+                    ParticleType::Steam => 5,
+                    _ => 0,
+                };
+                if new_val != 0 {
+                    break;
+                }
+            }
+            vec![ChunkCommand::Mutate(particle.particle_type, new_val)]
+        }
+        else {
+            let emit_type = match data_val {
+                1 => ParticleType::Water,
+                2 => ParticleType::Lava,  
+                3 => ParticleType::Sand,
+                4 => ParticleType::Gravel,
+                5 => ParticleType::Steam,
+                _ => ParticleType::Air,
+            };
+            
+            vec![
+                ChunkCommand::Add((GridVec{x: position.x - 1, y: position.y}, emit_type, 0)),
+                ChunkCommand::Add((GridVec{x: position.x + 1, y: position.y}, emit_type, 0)),
+                ChunkCommand::Add((GridVec{x: position.x, y: position.y - 1}, emit_type, 0)),
+                ChunkCommand::Add((GridVec{x: position.x, y: position.y + 1}, emit_type, 0)),
+            ]
+        }
+    }
+    
+    fn laser_beam_update(_position: GridVec, particle: Particle, _neighbors: [ParticleType; 8]) -> Vec<ChunkCommand> {
+        let dir_val = particle.data & !(1<<7);
+        let movement = match dir_val {
+            1 => GridVec::new(1, 0),
+            2 => GridVec::new(0, -1),
+            3 => GridVec::new(-1, 0),
+            _ => GridVec::new(0, 1),
+        };
+        
+        vec! [
+            ChunkCommand::MoveOrDestroy(vec![movement])
         ]
     }
     
-    fn lava_source_update(x: u8, y: u8) -> Vec<ChunkCommand> {
+    fn laser_emitter_update(position: GridVec, particle: Particle, _neighbors: [ParticleType; 8]) -> Vec<ChunkCommand> {
+        let dir_val = particle.data & !(1<<7);
+        let movement = match dir_val {
+            1 => GridVec::new(1, 0),
+            2 => GridVec::new(0, -1),
+            3 => GridVec::new(-1, 0),
+            _ => GridVec::new(0, 1),
+        };
+        
         vec![
-            ChunkCommand::Add((GridVec{x: x as i32 - 1, y: y as i32}, ParticleType::Lava)),
-            ChunkCommand::Add((GridVec{x: x as i32 + 1, y: y as i32}, ParticleType::Lava)),
-            ChunkCommand::Add((GridVec{x: x as i32, y: y as i32 - 1}, ParticleType::Lava)),
-            ChunkCommand::Add((GridVec{x: x as i32, y: y as i32 + 1}, ParticleType::Lava)),
-        ]
-    }
-    
-    fn laser_beam_update(_x: u8, _y: u8) -> Vec<ChunkCommand> {
-        vec![
-            ChunkCommand::MoveOrDestroy(vec![GridVec{x: 1, y: 0}]),
-        ]
-    }
-    
-    fn laser_emitter_update(x: u8, y: u8) -> Vec<ChunkCommand> {
-        vec![
-            ChunkCommand::Add((GridVec{x: x as i32 + 1, y: y as i32}, ParticleType::LaserBeam)),
+            ChunkCommand::Add((GridVec{x: position.x, y: position.y} + movement, ParticleType::LaserBeam, dir_val)),
         ]
     }
 } 

--- a/sandworld/src/region.rs
+++ b/sandworld/src/region.rs
@@ -293,7 +293,7 @@ impl Region {
         self.calc_update_priority();
 
         self.chunks.iter().for_each(|chunk| {
-            if chunk.dirty.is_some() || chunk.updated_last_frame.is_some()  {
+            if chunk.dirty.read().unwrap().is_some() || chunk.updated_last_frame.is_some()  {
                 self.updated_chunks.push(chunk.position);
             }
         });

--- a/sandworld/src/sandworld.rs
+++ b/sandworld/src/sandworld.rs
@@ -203,7 +203,7 @@ impl World {
 
         let chunkpos = World::get_chunkpos(&pos);
         let chunklocal = World::get_chunklocal(pos);
-        self.get_chunk_mut(&chunkpos).unwrap().replace_particle_filtered(chunklocal.x as u8, chunklocal.y as u8, new_val, replace_type);
+        self.get_chunk_mut(&chunkpos).unwrap().replace_particle_filtered(chunklocal.x as i16, chunklocal.y as i16, new_val, replace_type);
     }
 
     pub fn add_particle(&mut self, pos: GridVec, new_val: Particle) {
@@ -216,7 +216,7 @@ impl World {
         let chunkpos = World::get_chunkpos(&pos);
         let chunklocal = World::get_chunklocal(pos);
 
-        self.get_chunk_mut(&chunkpos).unwrap().add_particle(chunklocal.x as u8, chunklocal.y as u8, new_val);
+        self.get_chunk_mut(&chunkpos).unwrap().add_particle(chunklocal.x as i16, chunklocal.y as i16, new_val);
     }
 
     pub fn clear_circle(&mut self, pos: GridVec, radius: i32) {

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -6,7 +6,7 @@ pub struct CameraPlugin;
 impl Plugin for CameraPlugin {
     fn build(&self, app: &mut App) {
         app.add_startup_system(spawn_camera)
-        .add_system(camera_movement.label(crate::UpdateStages::Input));
+            .add_system(camera_movement.label(crate::UpdateStages::Input));
     }
 }
 
@@ -15,18 +15,24 @@ fn spawn_camera(mut commands: Commands) {
         transform: Transform::from_translation(Vec3::new(
             sandworld::WORLD_WIDTH as f32 / 2.,
             sandworld::WORLD_HEIGHT as f32 / 2.,
-            0.
+            0.,
         )),
         ..default()
     });
 }
 
-pub fn cam_bounds (ortho: &OrthographicProjection, transform: &GlobalTransform) -> GridBounds {
+pub fn cam_bounds(ortho: &OrthographicProjection, transform: &GlobalTransform) -> GridBounds {
     let width = (ortho.right - ortho.left) * ortho.scale;
     let height = (ortho.top - ortho.bottom) * ortho.scale;
-    let center = gridmath::GridVec::new(((ortho.right + ortho.left) / 2.).round() as i32, ((ortho.top + ortho.bottom) / 2.).round() as i32) 
-            + gridmath::GridVec::new(transform.translation().x as i32, transform.translation().y as i32);
-    let half_extents = gridmath::GridVec::new((width / 2.).ceil() as i32, (height / 2.).ceil() as i32);
+    let center = gridmath::GridVec::new(
+        ((ortho.right + ortho.left) / 2.).round() as i32,
+        ((ortho.top + ortho.bottom) / 2.).round() as i32,
+    ) + gridmath::GridVec::new(
+        transform.translation().x as i32,
+        transform.translation().y as i32,
+    );
+    let half_extents =
+        gridmath::GridVec::new((width / 2.).ceil() as i32, (height / 2.).ceil() as i32);
     gridmath::GridBounds::new(center, half_extents)
 }
 
@@ -36,7 +42,7 @@ fn camera_movement(
     keys: Res<Input<KeyCode>>,
 ) {
     let (_camera, mut ortho, mut camera_transform) = query.single_mut();
-    
+
     let mut log_scale = ortho.scale.ln();
     let move_speed = 128.;
     let zoom_speed = 0.5;
@@ -45,24 +51,31 @@ fn camera_movement(
     let min_zoom = 0.1;
 
     if keys.pressed(KeyCode::D) || keys.pressed(KeyCode::Right) {
-        camera_transform.translation = (camera_transform.right() * move_speed * time.delta_seconds()) + camera_transform.translation;
+        camera_transform.translation =
+            (camera_transform.right() * move_speed * time.delta_seconds())
+                + camera_transform.translation;
     }
     if keys.pressed(KeyCode::A) || keys.pressed(KeyCode::Left) {
-        camera_transform.translation = (camera_transform.left() * move_speed * time.delta_seconds()) + camera_transform.translation;
+        camera_transform.translation =
+            (camera_transform.left() * move_speed * time.delta_seconds())
+                + camera_transform.translation;
     }
     if keys.pressed(KeyCode::W) || keys.pressed(KeyCode::Up) {
-        camera_transform.translation = (camera_transform.up() * move_speed * time.delta_seconds()) + camera_transform.translation;
+        camera_transform.translation = (camera_transform.up() * move_speed * time.delta_seconds())
+            + camera_transform.translation;
     }
     if keys.pressed(KeyCode::S) || keys.pressed(KeyCode::Down) {
-        camera_transform.translation = (camera_transform.down() * move_speed * time.delta_seconds()) + camera_transform.translation;
+        camera_transform.translation =
+            (camera_transform.down() * move_speed * time.delta_seconds())
+                + camera_transform.translation;
     }
 
     if keys.any_pressed([KeyCode::PageUp, KeyCode::RBracket]) {
         log_scale -= zoom_speed * time.delta_seconds();
     }
-    if keys.any_pressed([KeyCode::PageDown, KeyCode::LBracket ]) {
+    if keys.any_pressed([KeyCode::PageDown, KeyCode::LBracket]) {
         log_scale += zoom_speed * time.delta_seconds();
-    }    
-    
+    }
+
     ortho.scale = log_scale.exp().clamp(min_zoom, max_zoom);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,16 +3,15 @@
 
 use std::mem::size_of;
 
-use bevy::{prelude::*, window::PresentMode };
+use bevy::{prelude::*, window::PresentMode};
 
-mod sandsim;
 mod camera;
-mod ui;
 mod perf;
+mod sandsim;
+mod ui;
 mod worldgen;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[derive(SystemLabel)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, SystemLabel)]
 enum UpdateStages {
     UI,
     Input,
@@ -20,22 +19,23 @@ enum UpdateStages {
     WorldDraw,
 }
 
-fn main(){
+fn main() {
     println!("particle size: {}", size_of::<sandworld::Particle>());
-    
+
     App::new()
-        .add_plugins(DefaultPlugins
-            .set(ImagePlugin::default_nearest())
-            .set(WindowPlugin {
-                window: WindowDescriptor {
-                    title: "Project Sandbox - Bevy".to_string(),
-                    width: 500.,
-                    height: 300.,
-                    present_mode: PresentMode::AutoVsync,
+        .add_plugins(
+            DefaultPlugins
+                .set(ImagePlugin::default_nearest())
+                .set(WindowPlugin {
+                    window: WindowDescriptor {
+                        title: "Project Sandbox - Bevy".to_string(),
+                        width: 500.,
+                        height: 300.,
+                        present_mode: PresentMode::AutoVsync,
+                        ..default()
+                    },
                     ..default()
-                },
-                ..default()
-             })
+                }),
         )
         .add_plugin(crate::sandsim::SandSimulationPlugin)
         .add_plugin(crate::camera::CameraPlugin)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 #![deny(clippy::all)]
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+use std::mem::size_of;
+
 use bevy::{prelude::*, window::PresentMode };
 
 mod sandsim;
@@ -19,6 +21,8 @@ enum UpdateStages {
 }
 
 fn main(){
+    println!("particle size: {}", size_of::<sandworld::Particle>());
+    
     App::new()
         .add_plugins(DefaultPlugins
             .set(ImagePlugin::default_nearest())

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -5,34 +5,35 @@ use bevy::prelude::*;
 #[derive(Resource)]
 pub struct FrameTimes {
     recent: VecDeque<f64>,
-    pub current_avg: f64, 
+    pub current_avg: f64,
 }
 
 #[derive(Resource)]
 pub struct PerfSettings {
-    pub target_frame_rate: u32
+    pub target_frame_rate: u32,
 }
 
 pub struct PerfControlPlugin;
 
 impl Plugin for PerfControlPlugin {
     fn build(&self, app: &mut App) {
-        app
-            .insert_resource(FrameTimes { recent: VecDeque::new(), current_avg: 0. })
-            .insert_resource(PerfSettings { target_frame_rate: 60 })
-            .add_system(frame_timing)
-        ;
+        app.insert_resource(FrameTimes {
+            recent: VecDeque::new(),
+            current_avg: 0.,
+        })
+        .insert_resource(PerfSettings {
+            target_frame_rate: 60,
+        })
+        .add_system(frame_timing);
     }
 }
 
-fn frame_timing(
-    time: Res<Time>,
-    mut timing_data: ResMut<FrameTimes>,
-) {
+fn frame_timing(time: Res<Time>, mut timing_data: ResMut<FrameTimes>) {
     timing_data.recent.push_back(time.delta_seconds_f64());
     if timing_data.recent.len() > 64 {
         timing_data.recent.pop_front();
     }
 
-    timing_data.current_avg = timing_data.recent.iter().fold(0., |total, val| { total + val }) / (timing_data.recent.len() as f64);
+    timing_data.current_avg = timing_data.recent.iter().fold(0., |total, val| total + val)
+        / (timing_data.recent.len() as f64);
 }

--- a/src/sandsim.rs
+++ b/src/sandsim.rs
@@ -1,8 +1,14 @@
+use bevy::{
+    prelude::*,
+    render::{
+        camera::RenderTarget,
+        render_resource::{Extent3d, TextureFormat},
+    },
+};
+use gridmath::{GridBounds, GridVec};
+use rand::{Rng};
+use sandworld::{ParticleType, CHUNK_SIZE};
 use std::{collections::VecDeque, sync::Arc};
-use bevy::{prelude::*, render::{render_resource::{Extent3d, TextureFormat}, camera::{RenderTarget}} };
-use gridmath::{GridVec, GridBounds};
-use sandworld::{CHUNK_SIZE, ParticleType};
-use rand::{Rng, rngs::ThreadRng};
 
 use crate::camera::cam_bounds;
 
@@ -12,15 +18,14 @@ impl Plugin for SandSimulationPlugin {
     fn build(&self, app: &mut App) {
         let mut rng = rand::thread_rng();
         let seed: u32 = rng.gen();
-        
+
         println!("Seed: {}", seed);
-        
+
         app.insert_resource(Sandworld {
-            world: sandworld::World::new(
-                Arc::new(
-                    crate::worldgen::LayeredPerlin::new(seed, 0.003, 0.01, 2.)
-                )
-        ) })
+            world: sandworld::World::new(Arc::new(crate::worldgen::LayeredPerlin::new(
+                seed, 0.003, 0.01, 2.,
+            ))),
+        })
         .insert_resource(DrawOptions {
             update_bounds: false,
             chunk_bounds: false,
@@ -77,7 +82,7 @@ pub struct BrushOptions {
 
 #[derive(Resource)]
 struct Sandworld {
-    world: sandworld::World
+    world: sandworld::World,
 }
 
 #[derive(Resource)]
@@ -88,10 +93,7 @@ pub struct WorldStats {
     pub target_chunk_updates: u64,
 }
 
-fn draw_mode_controls(
-    mut draw_options: ResMut<DrawOptions>,
-    keys: Res<Input<KeyCode>>,
-) {
+fn draw_mode_controls(mut draw_options: ResMut<DrawOptions>, keys: Res<Input<KeyCode>>) {
     draw_options.force_redraw_all = false;
 
     if keys.just_pressed(KeyCode::F2) {
@@ -110,10 +112,14 @@ fn draw_mode_controls(
 fn render_chunk_texture(chunk: &sandworld::Chunk, draw_options: &DrawOptions) -> Image {
     let side_size = sandworld::CHUNK_SIZE as u32;
     Image::new(
-        Extent3d { width: side_size, height: side_size, ..default() },
+        Extent3d {
+            width: side_size,
+            height: side_size,
+            ..default()
+        },
         bevy::render::render_resource::TextureDimension::D2,
         chunk.render_to_color_array(draw_options.update_bounds, draw_options.chunk_bounds),
-        TextureFormat::Rgba8Unorm
+        TextureFormat::Rgba8Unorm,
     )
 }
 
@@ -131,16 +137,22 @@ fn create_spawned_chunks(
 
             let chunk_size = sandworld::CHUNK_SIZE as f32;
 
-            commands.spawn(SpriteBundle {
-                transform: Transform::from_translation(Vec3::new((chunkpos.x as f32 + 0.5) * chunk_size, (chunkpos.y as f32 + 0.5) * chunk_size, 0.))
+            commands
+                .spawn(SpriteBundle {
+                    transform: Transform::from_translation(Vec3::new(
+                        (chunkpos.x as f32 + 0.5) * chunk_size,
+                        (chunkpos.y as f32 + 0.5) * chunk_size,
+                        0.,
+                    ))
                     .with_scale(Vec3::new(1., 1., 1.)),
-                texture: image_handle.clone(),
-                ..default()
-            }).insert(Chunk {
-                chunk_pos: chunkpos,
-                chunk_texture_handle: image_handle.clone(),
-                texture_dirty: false,
-            });
+                    texture: image_handle.clone(),
+                    ..default()
+                })
+                .insert(Chunk {
+                    chunk_pos: chunkpos,
+                    chunk_texture_handle: image_handle.clone(),
+                    texture_dirty: false,
+                });
         }
     }
 }
@@ -153,7 +165,13 @@ fn cull_hidden_chunks(
     let bounds = cam_bounds(ortho, cam_transform);
 
     chunk_query.par_for_each_mut(16, |(chunk, mut vis)| {
-        let chunk_bounds = GridBounds::new_from_corner(chunk.chunk_pos * (CHUNK_SIZE as i32), GridVec { x: CHUNK_SIZE as i32, y: CHUNK_SIZE as i32 });
+        let chunk_bounds = GridBounds::new_from_corner(
+            chunk.chunk_pos * (CHUNK_SIZE as i32),
+            GridVec {
+                x: CHUNK_SIZE as i32,
+                y: CHUNK_SIZE as i32,
+            },
+        );
         vis.is_visible = bounds.overlaps(chunk_bounds);
     });
 }
@@ -180,7 +198,10 @@ fn update_chunk_textures(
     for (mut chunk_comp, visibility) in chunk_query.iter_mut() {
         if chunk_comp.texture_dirty && visibility.is_visible {
             if let Some(chunk) = world.world.get_chunk(&chunk_comp.chunk_pos) {
-                images.set_untracked(chunk_comp.chunk_texture_handle.clone(), render_chunk_texture(chunk.as_ref(), &draw_options));
+                images.set_untracked(
+                    chunk_comp.chunk_texture_handle.clone(),
+                    render_chunk_texture(chunk.as_ref(), &draw_options),
+                );
                 updated_textures_count += 1;
                 chunk_comp.texture_dirty = false;
             }
@@ -190,14 +211,16 @@ fn update_chunk_textures(
     let update_end = std::time::Instant::now();
     let update_time = update_end - update_start;
 
-    world_stats.chunk_texture_update_time.push_back((update_time.as_secs_f64(), updated_textures_count));
+    world_stats
+        .chunk_texture_update_time
+        .push_back((update_time.as_secs_f64(), updated_textures_count));
     if world_stats.chunk_texture_update_time.len() > 64 {
         world_stats.chunk_texture_update_time.pop_front();
     }
 }
 
 fn sand_update(
-    mut world: ResMut<Sandworld>, 
+    mut world: ResMut<Sandworld>,
     mut world_stats: ResMut<WorldStats>,
     perf_settings: Res<crate::perf::PerfSettings>,
     cam_query: Query<(&OrthographicProjection, &GlobalTransform)>,
@@ -211,7 +234,8 @@ fn sand_update(
         for (time, count) in &world_stats.sand_update_time {
             chunk_updates_per_second_avg += (*count + 1) as f64 / time;
         }
-        chunk_updates_per_second_avg = chunk_updates_per_second_avg / (world_stats.sand_update_time.len() as f64);
+        chunk_updates_per_second_avg =
+            chunk_updates_per_second_avg / (world_stats.sand_update_time.len() as f64);
         target_chunk_updates = (target_update_seconds * chunk_updates_per_second_avg) as u64;
         world_stats.target_chunk_updates = target_chunk_updates;
     }
@@ -223,11 +247,13 @@ fn sand_update(
     let stats = world.world.update(bounds, target_chunk_updates);
     let update_end = std::time::Instant::now();
     let update_time = update_end - update_start;
-    world_stats.sand_update_time.push_back((update_time.as_secs_f64(), stats.chunk_updates));
+    world_stats
+        .sand_update_time
+        .push_back((update_time.as_secs_f64(), stats.chunk_updates));
     if world_stats.sand_update_time.len() > 64 {
         world_stats.sand_update_time.pop_front();
     }
-    world_stats.update_stats = Some(stats);  
+    world_stats.update_stats = Some(stats);
 }
 
 fn world_interact(
@@ -236,9 +262,10 @@ fn world_interact(
     q_cam: Query<(&Camera, &GlobalTransform)>,
     mut sand: ResMut<Sandworld>,
     buttons: Res<Input<MouseButton>>,
-    brush_options: Res<BrushOptions>
+    brush_options: Res<BrushOptions>,
 ) {
-    if !capture_state.click_consumed && buttons.any_pressed([MouseButton::Left, MouseButton::Right]) {
+    if !capture_state.click_consumed && buttons.any_pressed([MouseButton::Left, MouseButton::Right])
+    {
         // get the camera info and transform
         // assuming there is exactly one main camera entity, so query::single() is OK
         let (camera, camera_transform) = q_cam.single();
@@ -259,7 +286,8 @@ fn world_interact(
             let ndc = (screen_pos / window_size) * 2.0 - Vec2::ONE;
 
             // matrix for undoing the projection and camera transform
-            let ndc_to_world = camera_transform.compute_matrix() * camera.projection_matrix().inverse();
+            let ndc_to_world =
+                camera_transform.compute_matrix() * camera.projection_matrix().inverse();
 
             // use it to convert ndc to world-space coordinates
             let world_pos = ndc_to_world.project_point3(ndc.extend(-1.0));
@@ -269,16 +297,31 @@ fn world_interact(
 
             let gridpos = GridVec::new(world_pos.x as i32, world_pos.y as i32);
 
-            if buttons.pressed(MouseButton::Left){
+            if buttons.pressed(MouseButton::Left) {
                 match brush_options.brush_mode {
-                    BrushMode::Place(part_type, data) => sand.world.place_circle(gridpos, brush_options.radius, sandworld::Particle::new_with_data(part_type, data), false),
-                    BrushMode::Melt => sand.world.temp_change_circle(gridpos, brush_options.radius, 0.01, 300),
+                    BrushMode::Place(part_type, data) => sand.world.place_circle(
+                        gridpos,
+                        brush_options.radius,
+                        sandworld::Particle::new_with_data(part_type, data),
+                        false,
+                    ),
+                    BrushMode::Melt => {
+                        sand.world
+                            .temp_change_circle(gridpos, brush_options.radius, 0.01, 500)
+                    }
                     BrushMode::Break => sand.world.break_circle(gridpos, brush_options.radius, 0.1),
-                    BrushMode::Chill => sand.world.temp_change_circle(gridpos, brush_options.radius, 0.01, -100),
+                    BrushMode::Chill => {
+                        sand.world
+                            .temp_change_circle(gridpos, brush_options.radius, 0.01, -100)
+                    }
                 }
-            }
-            else if buttons.pressed(MouseButton::Right) {
-                sand.world.place_circle(gridpos, 10, sandworld::Particle::new(sandworld::ParticleType::Air), true);
+            } else if buttons.pressed(MouseButton::Right) {
+                sand.world.place_circle(
+                    gridpos,
+                    10,
+                    sandworld::Particle::new(sandworld::ParticleType::Air),
+                    true,
+                );
             }
         }
     }

--- a/src/sandsim.rs
+++ b/src/sandsim.rs
@@ -28,7 +28,7 @@ impl Plugin for SandSimulationPlugin {
             force_redraw_all: false,
         })
         .insert_resource(BrushOptions {
-            brush_mode: BrushMode::Place(ParticleType::Sand),
+            brush_mode: BrushMode::Place(ParticleType::Sand, 0),
             radius: 10,
         })
         .insert_resource(WorldStats {
@@ -63,7 +63,7 @@ pub struct DrawOptions {
 
 #[derive(PartialEq, Eq, Clone)]
 pub enum BrushMode {
-    Place(sandworld::ParticleType),
+    Place(sandworld::ParticleType, u8),
     Melt,
     Break,
     Chill,
@@ -271,7 +271,7 @@ fn world_interact(
 
             if buttons.pressed(MouseButton::Left){
                 match brush_options.brush_mode {
-                    BrushMode::Place(part_type) => sand.world.place_circle(gridpos, brush_options.radius, sandworld::Particle::new(part_type), false),
+                    BrushMode::Place(part_type, data) => sand.world.place_circle(gridpos, brush_options.radius, sandworld::Particle::new_with_data(part_type, data), false),
                     BrushMode::Melt => sand.world.temp_change_circle(gridpos, brush_options.radius, 0.01, 300),
                     BrushMode::Break => sand.world.break_circle(gridpos, brush_options.radius, 0.1),
                     BrushMode::Chill => sand.world.temp_change_circle(gridpos, brush_options.radius, 0.01, -100),

--- a/src/sandsim.rs
+++ b/src/sandsim.rs
@@ -272,9 +272,9 @@ fn world_interact(
             if buttons.pressed(MouseButton::Left){
                 match brush_options.brush_mode {
                     BrushMode::Place(part_type) => sand.world.place_circle(gridpos, brush_options.radius, sandworld::Particle::new(part_type), false),
-                    BrushMode::Melt => sand.world.melt_circle(gridpos, brush_options.radius, 0.01),
+                    BrushMode::Melt => sand.world.temp_change_circle(gridpos, brush_options.radius, 0.01, 300),
                     BrushMode::Break => sand.world.break_circle(gridpos, brush_options.radius, 0.1),
-                    BrushMode::Chill => sand.world.chill_circle(gridpos, brush_options.radius, 0.01),
+                    BrushMode::Chill => sand.world.temp_change_circle(gridpos, brush_options.radius, 0.01, -100),
                 }
             }
             else if buttons.pressed(MouseButton::Right) {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,9 +1,8 @@
+use crate::sandsim::{BrushMode, BrushOptions};
 use bevy::prelude::*;
-use crate::sandsim::{BrushOptions, BrushMode};
 use sandworld::ParticleType;
 
 pub struct UiPlugin;
-
 
 #[derive(Resource)]
 pub struct PointerCaptureState {
@@ -16,81 +15,91 @@ const PRESSED_BUTTON: Color = Color::rgb(0.35, 0.75, 0.35);
 
 impl Plugin for UiPlugin {
     fn build(&self, app: &mut App) {
-        app
-            .add_startup_system(setup_buttons)
+        app.add_startup_system(setup_buttons)
             .add_startup_system(spawn_performance_info_text)
-            .insert_resource(PointerCaptureState { click_consumed: false })
-            .add_system(button_system.label(crate::UpdateStages::UI)
-                .before(crate::UpdateStages::Input))
-            .add_system(update_performance_text.label(crate::UpdateStages::UI)
-                .after(crate::UpdateStages::WorldUpdate))
-        ;
+            .insert_resource(PointerCaptureState {
+                click_consumed: false,
+            })
+            .add_system(
+                button_system
+                    .label(crate::UpdateStages::UI)
+                    .before(crate::UpdateStages::Input),
+            )
+            .add_system(
+                update_performance_text
+                    .label(crate::UpdateStages::UI)
+                    .after(crate::UpdateStages::WorldUpdate),
+            );
     }
 }
 
 #[derive(Component)]
 struct PerformanceReadout;
 
-fn spawn_performance_info_text(
-    mut commands: Commands, 
-    asset_server: Res<AssetServer>
-) {
-    commands.spawn(TextBundle::from_sections([
-            TextSection {
-                value: "FPS: 69".to_string(),
-                style: TextStyle {
-                    font: asset_server.load("fonts/FiraMono-Medium.ttf"),
-                    font_size: 30.0,
-                    color: Color::rgb(0.9, 0.9, 0.9),
-                }
-            },
-            TextSection {
-                value: "\nLoaded Regions: 000".to_string(),
-                style: TextStyle {
-                    font: asset_server.load("fonts/FiraMono-Medium.ttf"),
-                    font_size: 20.0,
-                    color: Color::rgb(0.9, 0.9, 0.9),
-                }
-            },
-            TextSection {
-                value: "\nUpdated Regions: 000".to_string(),
-                style: TextStyle {
-                    font: asset_server.load("fonts/FiraMono-Medium.ttf"),
-                    font_size: 20.0,
-                    color: Color::rgb(0.9, 0.9, 0.9),
-                }
-            },
-            TextSection {
-                value: "\nChunk Updates: 000".to_string(),
-                style: TextStyle {
-                    font: asset_server.load("fonts/FiraMono-Medium.ttf"),
-                    font_size: 20.0,
-                    color: Color::rgb(0.9, 0.9, 0.9),
-                }
-            },
-            TextSection {
-                value: "\nAvg time per chunk".to_string(),
-                style: TextStyle {
-                    font: asset_server.load("fonts/FiraMono-Medium.ttf"),
-                    font_size: 20.0,
-                    color: Color::rgb(0.9, 0.9, 0.6),
-                }
-            },
-            TextSection {
-                value: "\nAvg render time per chunk".to_string(),
-                style: TextStyle {
-                    font: asset_server.load("fonts/FiraMono-Medium.ttf"),
-                    font_size: 20.0,
-                    color: Color::rgb(0.9, 0.9, 0.6),
-                }
-            }
-        ]
-    ).with_style(Style {
-        position_type: PositionType::Absolute,
-        position: UiRect { left: Val::Px(10.0), top: Val::Px(10.0), ..Default::default() },
-        ..Default::default()
-    })
-).insert(PerformanceReadout{});
+fn spawn_performance_info_text(mut commands: Commands, asset_server: Res<AssetServer>) {
+    commands
+        .spawn(
+            TextBundle::from_sections([
+                TextSection {
+                    value: "FPS: 69".to_string(),
+                    style: TextStyle {
+                        font: asset_server.load("fonts/FiraMono-Medium.ttf"),
+                        font_size: 30.0,
+                        color: Color::rgb(0.9, 0.9, 0.9),
+                    },
+                },
+                TextSection {
+                    value: "\nLoaded Regions: 000".to_string(),
+                    style: TextStyle {
+                        font: asset_server.load("fonts/FiraMono-Medium.ttf"),
+                        font_size: 20.0,
+                        color: Color::rgb(0.9, 0.9, 0.9),
+                    },
+                },
+                TextSection {
+                    value: "\nUpdated Regions: 000".to_string(),
+                    style: TextStyle {
+                        font: asset_server.load("fonts/FiraMono-Medium.ttf"),
+                        font_size: 20.0,
+                        color: Color::rgb(0.9, 0.9, 0.9),
+                    },
+                },
+                TextSection {
+                    value: "\nChunk Updates: 000".to_string(),
+                    style: TextStyle {
+                        font: asset_server.load("fonts/FiraMono-Medium.ttf"),
+                        font_size: 20.0,
+                        color: Color::rgb(0.9, 0.9, 0.9),
+                    },
+                },
+                TextSection {
+                    value: "\nAvg time per chunk".to_string(),
+                    style: TextStyle {
+                        font: asset_server.load("fonts/FiraMono-Medium.ttf"),
+                        font_size: 20.0,
+                        color: Color::rgb(0.9, 0.9, 0.6),
+                    },
+                },
+                TextSection {
+                    value: "\nAvg render time per chunk".to_string(),
+                    style: TextStyle {
+                        font: asset_server.load("fonts/FiraMono-Medium.ttf"),
+                        font_size: 20.0,
+                        color: Color::rgb(0.9, 0.9, 0.6),
+                    },
+                },
+            ])
+            .with_style(Style {
+                position_type: PositionType::Absolute,
+                position: UiRect {
+                    left: Val::Px(10.0),
+                    top: Val::Px(10.0),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+        )
+        .insert(PerformanceReadout {});
 }
 
 fn update_performance_text(
@@ -103,12 +112,19 @@ fn update_performance_text(
     if draw_options.world_stats {
         vis.is_visible = true;
 
-        text.sections[0].value = format!("FPS: {} ({:.1}ms)", (1. / frame_times.current_avg).round() as u32, frame_times.current_avg * 1000.);
+        text.sections[0].value = format!(
+            "FPS: {} ({:.1}ms)",
+            (1. / frame_times.current_avg).round() as u32,
+            frame_times.current_avg * 1000.
+        );
 
         if let Some(world_stats) = &stats.update_stats {
             text.sections[1].value = format!("\nLoaded Regions: {}", world_stats.loaded_regions);
             text.sections[2].value = format!("\nRegion Updates: {}", world_stats.region_updates);
-            text.sections[3].value = format!("\nChunk Updates [Target]: {} [{}]", world_stats.chunk_updates, stats.target_chunk_updates);
+            text.sections[3].value = format!(
+                "\nChunk Updates [Target]: {} [{}]",
+                world_stats.chunk_updates, stats.target_chunk_updates
+            );
 
             let mut texture_update_time_avg = 0.;
             let mut texture_update_per_chunk_avg = 0.;
@@ -116,10 +132,16 @@ fn update_performance_text(
                 texture_update_time_avg += time;
                 texture_update_per_chunk_avg += time / (*count as f64);
             }
-            texture_update_time_avg = texture_update_time_avg / (stats.chunk_texture_update_time.len() as f64);
-            texture_update_per_chunk_avg = texture_update_per_chunk_avg / (stats.chunk_texture_update_time.len() as f64);
+            texture_update_time_avg =
+                texture_update_time_avg / (stats.chunk_texture_update_time.len() as f64);
+            texture_update_per_chunk_avg =
+                texture_update_per_chunk_avg / (stats.chunk_texture_update_time.len() as f64);
 
-            text.sections[5].value = format!("\nTex Update time:  {:.2}ms - Avg time per chunk: {:.3}ms", texture_update_time_avg * 1000., texture_update_per_chunk_avg * 1000.);
+            text.sections[5].value = format!(
+                "\nTex Update time:  {:.2}ms - Avg time per chunk: {:.3}ms",
+                texture_update_time_avg * 1000.,
+                texture_update_per_chunk_avg * 1000.
+            );
         }
 
         let mut chunk_updates_per_second_avg = 0.;
@@ -128,12 +150,17 @@ fn update_performance_text(
             chunk_updates_per_second_avg += *count as f64 / time;
             total_sand_update_second_avg += time;
         }
-        chunk_updates_per_second_avg = chunk_updates_per_second_avg / (stats.sand_update_time.len() as f64);
-        total_sand_update_second_avg = total_sand_update_second_avg / (stats.sand_update_time.len() as f64);
+        chunk_updates_per_second_avg =
+            chunk_updates_per_second_avg / (stats.sand_update_time.len() as f64);
+        total_sand_update_second_avg =
+            total_sand_update_second_avg / (stats.sand_update_time.len() as f64);
 
-        text.sections[4].value = format!("\nSand update time: {:.2}ms - Avg time per chunk: {:.3}ms", total_sand_update_second_avg * 1000., 1000. / chunk_updates_per_second_avg);
-    }
-    else {
+        text.sections[4].value = format!(
+            "\nSand update time: {:.2}ms - Avg time per chunk: {:.3}ms",
+            total_sand_update_second_avg * 1000.,
+            1000. / chunk_updates_per_second_avg
+        );
+    } else {
         vis.is_visible = false;
     }
 }
@@ -145,9 +172,12 @@ struct ToolSelector {
 }
 
 fn spawn_tool_selector_button(
-    commands: &mut Commands, 
-    asset_server: &Res<AssetServer>, 
-    label: &str, brush_mode: BrushMode, radius: i32) {
+    commands: &mut Commands,
+    asset_server: &Res<AssetServer>,
+    label: &str,
+    brush_mode: BrushMode,
+    radius: i32,
+) {
     commands
         .spawn(ButtonBundle {
             style: Style {
@@ -167,10 +197,7 @@ fn spawn_tool_selector_button(
             background_color: NORMAL_BUTTON.into(),
             ..default()
         })
-        .insert(ToolSelector {
-            brush_mode,
-            radius,
-        })
+        .insert(ToolSelector { brush_mode, radius })
         .with_children(|parent| {
             parent.spawn(TextBundle::from_section(
                 label,
@@ -187,24 +214,81 @@ fn setup_buttons(mut commands: Commands, asset_server: Res<AssetServer>) {
     spawn_tool_selector_button(&mut commands, &asset_server, "MELT", BrushMode::Melt, 10);
     spawn_tool_selector_button(&mut commands, &asset_server, "BREAK", BrushMode::Break, 10);
     spawn_tool_selector_button(&mut commands, &asset_server, "CHILL", BrushMode::Chill, 20);
-    spawn_tool_selector_button(&mut commands, &asset_server, "Stone", BrushMode::Place(ParticleType::Stone, 0), 20);
-    spawn_tool_selector_button(&mut commands, &asset_server, "Gravel", BrushMode::Place(ParticleType::Gravel, 0), 10);
-    spawn_tool_selector_button(&mut commands, &asset_server, "Sand", BrushMode::Place(ParticleType::Sand, 0), 10);
-    spawn_tool_selector_button(&mut commands, &asset_server, "Ice", BrushMode::Place(ParticleType::Ice, 0), 10);
-    spawn_tool_selector_button(&mut commands, &asset_server, "Water", BrushMode::Place(ParticleType::Water, 0), 10);
-    spawn_tool_selector_button(&mut commands, &asset_server, "Steam", BrushMode::Place(ParticleType::Steam, 0), 10);
-    spawn_tool_selector_button(&mut commands, &asset_server, "Lava", BrushMode::Place(ParticleType::Lava, 0), 10);
-    spawn_tool_selector_button(&mut commands, &asset_server, "Emit", BrushMode::Place(ParticleType::Source, 0), 1);
-    spawn_tool_selector_button(&mut commands, &asset_server, "LaserR", BrushMode::Place(ParticleType::LaserEmitter, 1), 1);
-    spawn_tool_selector_button(&mut commands, &asset_server, "LaserL", BrushMode::Place(ParticleType::LaserEmitter, 3), 1);
+    spawn_tool_selector_button(
+        &mut commands,
+        &asset_server,
+        "Stone",
+        BrushMode::Place(ParticleType::Stone, 0),
+        20,
+    );
+    spawn_tool_selector_button(
+        &mut commands,
+        &asset_server,
+        "Gravel",
+        BrushMode::Place(ParticleType::Gravel, 0),
+        10,
+    );
+    spawn_tool_selector_button(
+        &mut commands,
+        &asset_server,
+        "Sand",
+        BrushMode::Place(ParticleType::Sand, 0),
+        10,
+    );
+    spawn_tool_selector_button(
+        &mut commands,
+        &asset_server,
+        "Ice",
+        BrushMode::Place(ParticleType::Ice, 0),
+        10,
+    );
+    spawn_tool_selector_button(
+        &mut commands,
+        &asset_server,
+        "Water",
+        BrushMode::Place(ParticleType::Water, 0),
+        10,
+    );
+    spawn_tool_selector_button(
+        &mut commands,
+        &asset_server,
+        "Steam",
+        BrushMode::Place(ParticleType::Steam, 0),
+        10,
+    );
+    spawn_tool_selector_button(
+        &mut commands,
+        &asset_server,
+        "Lava",
+        BrushMode::Place(ParticleType::Lava, 0),
+        10,
+    );
+    spawn_tool_selector_button(
+        &mut commands,
+        &asset_server,
+        "Emit",
+        BrushMode::Place(ParticleType::Source, 0),
+        1,
+    );
+    spawn_tool_selector_button(
+        &mut commands,
+        &asset_server,
+        "LaserR",
+        BrushMode::Place(ParticleType::LaserEmitter, 1),
+        1,
+    );
+    spawn_tool_selector_button(
+        &mut commands,
+        &asset_server,
+        "LaserL",
+        BrushMode::Place(ParticleType::LaserEmitter, 3),
+        1,
+    );
 }
 
 fn button_system(
     mut capture_state: ResMut<PointerCaptureState>,
-    mut interaction_query: Query<
-        (&Interaction, &mut BackgroundColor, &ToolSelector),
-        With<Button>,
-    >,
+    mut interaction_query: Query<(&Interaction, &mut BackgroundColor, &ToolSelector), With<Button>>,
     mut brush_options: ResMut<BrushOptions>,
 ) {
     capture_state.click_consumed = false;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -187,16 +187,16 @@ fn setup_buttons(mut commands: Commands, asset_server: Res<AssetServer>) {
     spawn_tool_selector_button(&mut commands, &asset_server, "MELT", BrushMode::Melt, 10);
     spawn_tool_selector_button(&mut commands, &asset_server, "BREAK", BrushMode::Break, 10);
     spawn_tool_selector_button(&mut commands, &asset_server, "CHILL", BrushMode::Chill, 20);
-    spawn_tool_selector_button(&mut commands, &asset_server, "Stone", BrushMode::Place(ParticleType::Stone), 20);
-    spawn_tool_selector_button(&mut commands, &asset_server, "Gravel", BrushMode::Place(ParticleType::Gravel), 10);
-    spawn_tool_selector_button(&mut commands, &asset_server, "Sand", BrushMode::Place(ParticleType::Sand), 10);
-    spawn_tool_selector_button(&mut commands, &asset_server, "Ice", BrushMode::Place(ParticleType::Ice), 10);
-    spawn_tool_selector_button(&mut commands, &asset_server, "Water", BrushMode::Place(ParticleType::Water), 10);
-    spawn_tool_selector_button(&mut commands, &asset_server, "Steam", BrushMode::Place(ParticleType::Steam), 10);
-    spawn_tool_selector_button(&mut commands, &asset_server, "Lava", BrushMode::Place(ParticleType::Lava), 10);
-    spawn_tool_selector_button(&mut commands, &asset_server, "WSource", BrushMode::Place(ParticleType::Source), 1);
-    spawn_tool_selector_button(&mut commands, &asset_server, "LSource", BrushMode::Place(ParticleType::LSource), 1);
-    spawn_tool_selector_button(&mut commands, &asset_server, "Laser", BrushMode::Place(ParticleType::LaserEmitter), 1);
+    spawn_tool_selector_button(&mut commands, &asset_server, "Stone", BrushMode::Place(ParticleType::Stone, 0), 20);
+    spawn_tool_selector_button(&mut commands, &asset_server, "Gravel", BrushMode::Place(ParticleType::Gravel, 0), 10);
+    spawn_tool_selector_button(&mut commands, &asset_server, "Sand", BrushMode::Place(ParticleType::Sand, 0), 10);
+    spawn_tool_selector_button(&mut commands, &asset_server, "Ice", BrushMode::Place(ParticleType::Ice, 0), 10);
+    spawn_tool_selector_button(&mut commands, &asset_server, "Water", BrushMode::Place(ParticleType::Water, 0), 10);
+    spawn_tool_selector_button(&mut commands, &asset_server, "Steam", BrushMode::Place(ParticleType::Steam, 0), 10);
+    spawn_tool_selector_button(&mut commands, &asset_server, "Lava", BrushMode::Place(ParticleType::Lava, 0), 10);
+    spawn_tool_selector_button(&mut commands, &asset_server, "Emit", BrushMode::Place(ParticleType::Source, 0), 1);
+    spawn_tool_selector_button(&mut commands, &asset_server, "LaserR", BrushMode::Place(ParticleType::LaserEmitter, 1), 1);
+    spawn_tool_selector_button(&mut commands, &asset_server, "LaserL", BrushMode::Place(ParticleType::LaserEmitter, 3), 1);
 }
 
 fn button_system(

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -196,6 +196,7 @@ fn setup_buttons(mut commands: Commands, asset_server: Res<AssetServer>) {
     spawn_tool_selector_button(&mut commands, &asset_server, "Lava", BrushMode::Place(ParticleType::Lava), 10);
     spawn_tool_selector_button(&mut commands, &asset_server, "WSource", BrushMode::Place(ParticleType::Source), 1);
     spawn_tool_selector_button(&mut commands, &asset_server, "LSource", BrushMode::Place(ParticleType::LSource), 1);
+    spawn_tool_selector_button(&mut commands, &asset_server, "Laser", BrushMode::Place(ParticleType::LaserEmitter), 1);
 }
 
 fn button_system(

--- a/src/worldgen.rs
+++ b/src/worldgen.rs
@@ -1,8 +1,6 @@
-
-use noise::{NoiseFn, Perlin, Simplex};
-use sandworld::{WorldGenerator, Particle, ParticleType};
 use gridmath::GridVec;
-
+use noise::{NoiseFn, Perlin};
+use sandworld::{Particle, ParticleType, WorldGenerator};
 
 pub struct Blankworld {}
 
@@ -33,20 +31,15 @@ impl WorldGenerator for Blankworld {
 
 impl WorldGenerator for FlatPlain {
     fn get_particle(&self, world_pos: GridVec) -> Particle {
-        Particle::new(
-            if world_pos.y > self.stone_height { 
-                if world_pos.y > self.sand_height {
-                    ParticleType::Air 
-                }
-                else {
-                    ParticleType::Sand
-                }
-            } 
-            else { 
-                ParticleType::Stone 
+        Particle::new(if world_pos.y > self.stone_height {
+            if world_pos.y > self.sand_height {
+                ParticleType::Air
+            } else {
+                ParticleType::Sand
             }
-        )
-        
+        } else {
+            ParticleType::Stone
+        })
     }
 }
 
@@ -63,15 +56,17 @@ impl BasicPerlin {
 
 impl WorldGenerator for BasicPerlin {
     fn get_particle(&self, world_pos: GridVec) -> Particle {
-        let sample_pos = [world_pos.x as f64 * self.scale_x, world_pos.y as f64 * self.scale_y];
+        let sample_pos = [
+            world_pos.x as f64 * self.scale_x,
+            world_pos.y as f64 * self.scale_y,
+        ];
         let noise_val = self.noise.get(sample_pos);
-            
-        Particle::new(if noise_val < self.stone_threshold { 
+
+        Particle::new(if noise_val < self.stone_threshold {
             ParticleType::Air
-        } 
-        else { 
+        } else {
             ParticleType::Stone
-        }) 
+        })
     }
 }
 
@@ -88,18 +83,25 @@ impl LayeredPerlin {
 
 impl WorldGenerator for LayeredPerlin {
     fn get_particle(&self, world_pos: GridVec) -> Particle {
-        let macro_sample_pos = [world_pos.x as f64 * self.scale_macro, world_pos.y as f64 * self.scale_macro];
-        let detail_sample_pos = [world_pos.x as f64 * self.scale_detail, world_pos.y as f64 * self.scale_detail];
+        let macro_sample_pos = [
+            world_pos.x as f64 * self.scale_macro,
+            world_pos.y as f64 * self.scale_macro,
+        ];
+        let detail_sample_pos = [
+            world_pos.x as f64 * self.scale_detail,
+            world_pos.y as f64 * self.scale_detail,
+        ];
         //let cave_sample_pos = [world_pos.x as f64 * self.scale_cave_density, world_pos.y as f64 * self.scale_cave_density];
         let macro_noise_val = self.noise.get(macro_sample_pos);
         let detail_noise_val = self.noise.get(detail_sample_pos);
         //let cave_sample_noise_val = self.noise.get(cave_sample_pos);
-        
-        Particle::new(if detail_noise_val < macro_noise_val * self.cave_noisiness { 
-            ParticleType::Air
-        } 
-        else { 
-            ParticleType::Stone
-        }) 
+
+        Particle::new(
+            if detail_noise_val < macro_noise_val * self.cave_noisiness {
+                ParticleType::Air
+            } else {
+                ParticleType::Stone
+            },
+        )
     }
 }


### PR DESCRIPTION
Refactors most of the particle update logic. Unifies temperature based state changes to share implementation. 
Also adds a new system for custom logic to be used for a particle type, and a few uses of that. 
Particles can now store up to 7 bits of data that can be used for this custom update.

- unfied state change logic
- refactored melt and chill brushes
- factoring type updates out of chunk update
- working on update refactor
- thread safe chunk dirty
- added particle custom data field
- refactored updates further, added some new things to use it
