### PR TITLE
Sleeping Regions

### DIFF
--- a/gridmath/Cargo.toml
+++ b/gridmath/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rand = "0.8.4"
+rand = "0.8.5"
 
 [dev-dependencies]
-criterion = "0.4.0"
+criterion = "0.5.1"
 
 [[bench]]
 name = "bounds_benchmark"

--- a/sandworld/src/chunk.rs
+++ b/sandworld/src/chunk.rs
@@ -1,6 +1,5 @@
 pub const CHUNK_SIZE: u8 = 64;
 use std::collections::{HashMap, HashSet};
-use std::io::SeekFrom;
 use std::sync::{Arc, RwLock};
 
 use gridmath::*;
@@ -18,12 +17,14 @@ pub struct Chunk {
     pub(crate) updated_last_frame: Option<GridBounds>,
 }
 
+#[derive(Clone)]
 enum CompressedParticleData {
     Uncompressed(Vec<Particle>),
     Monotype(Particle),
     RunLength((HashMap<u8, Particle>, Vec<(u8, u8)>)),
 }
 
+#[derive(Clone)]
 pub struct CompressedChunk {
     pub position: GridVec,
     particle_data: CompressedParticleData,

--- a/sandworld/src/chunk.rs
+++ b/sandworld/src/chunk.rs
@@ -134,6 +134,8 @@ impl CompressedChunk {
             CompressedParticleData::RunLength((_map, _data)) => {}
         }
 
+        // created.mark_self_dirty();
+
         created
     }
 }

--- a/sandworld/src/particle.rs
+++ b/sandworld/src/particle.rs
@@ -2,7 +2,7 @@ use gridmath::GridVec;
 use rand::Rng;
 use once_cell::sync::Lazy;
 
-#[derive(PartialEq, Eq, Debug, Copy, Clone)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone, Hash)]
 pub enum ParticleType {
     Air,
     Sand,
@@ -22,7 +22,7 @@ pub enum ParticleType {
     Dirty,
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Hash)]
 pub struct Particle {
     pub particle_type: ParticleType,
     /*
@@ -122,6 +122,14 @@ impl Particle {
     }
 }
 
+impl PartialEq for Particle {
+    fn eq(&self, other: &Self) -> bool {
+        self.particle_type == other.particle_type && (self.data & 0b0111111) == (other.data & 0b01111111)
+    }
+}
+
+impl Eq for Particle {}
+
 impl Default for Particle {
     fn default() -> Self { Particle::new(ParticleType::Air) }
 }
@@ -179,7 +187,7 @@ pub fn get_state_change_for_type(particle_type: ParticleType) -> StateChange {
     match particle_type {
         ParticleType::Ice => StateChange{           melt: Some((-28, ParticleType::Water, 0.5)),        freeze: None },
         ParticleType::Water => StateChange{         melt: Some((100, ParticleType::Steam, 0.15)),       freeze: Some((-40, ParticleType::Ice, 0.15)) },
-        ParticleType::Steam => StateChange{         melt: None,                                         freeze: Some((150, ParticleType::Water, 0.25))},
+        ParticleType::Steam => StateChange{         melt: None,                                         freeze: Some((200, ParticleType::Water, 0.25))},
         ParticleType::Stone => StateChange{         melt: Some((700, ParticleType::Lava, 0.15)),        freeze: None },
         ParticleType::Gravel => StateChange{        melt: Some((680, ParticleType::Lava, 0.2)),         freeze: None },
         ParticleType::Sand => StateChange{          melt: Some((650, ParticleType::MoltenGlass, 0.2)),  freeze: None },

--- a/sandworld/src/region.rs
+++ b/sandworld/src/region.rs
@@ -224,8 +224,9 @@ impl Region {
         for self_chunk_pos in self_chunks.iter() {
             for other_chunk_pos in other_chunks.iter() {
                 let self_chunk = &mut self.chunks[Region::local_chunkpos_to_region_index(self_chunk_pos)];
-                
-                self_chunk.check_remove_neighbor(*other_chunk_pos);
+                let other_chunk_pos_adj = (*other_regpos * REGION_SIZE as i32) + *other_chunk_pos;
+
+                self_chunk.check_remove_neighbor(other_chunk_pos_adj);
             }
         }
     }

--- a/sandworld/src/region.rs
+++ b/sandworld/src/region.rs
@@ -19,6 +19,7 @@ pub struct Region {
     generator: Arc<dyn WorldGenerator + Send + Sync>,
 }
 
+#[derive(Clone)]
 pub struct CompressedRegion {
     pub position: GridVec,
     chunks: Vec<CompressedChunk>,
@@ -70,6 +71,16 @@ impl Region {
         self.chunks.par_iter_mut().for_each(|chunk| {
             chunk.regenerate(&self.generator);
         });
+    }
+
+    pub fn get_chunk_positions(&self) -> Vec<GridVec> {
+        let mut poses = Vec::new();
+
+        for chunk in self.chunks.iter() {
+            poses.push(chunk.position);
+        }
+
+        return poses;
     }
 
     pub fn compress_region(&self) -> CompressedRegion {

--- a/sandworld/src/sandworld.rs
+++ b/sandworld/src/sandworld.rs
@@ -167,8 +167,7 @@ impl World {
                 to_remove.push(region.position);
                 
                 self.removed_chunks.append(&mut region.get_chunk_positions());
-
-                println!("Compressing region: {}", region.position);
+                
                 let mut reg = Region::new(region.position, self.generator.clone());
                 swap(region, &mut reg);
                 self.unloading_regions.push_back(UnloadingRegion::new(region.position, reg));

--- a/sandworld/src/sandworld.rs
+++ b/sandworld/src/sandworld.rs
@@ -91,6 +91,7 @@ impl World {
                 }
         
                 self.regions.push(retrieved);
+                println!("Decompressed region: {}", regpos);
                 return true;
             }
         }
@@ -123,6 +124,7 @@ impl World {
             if region.staleness > staleness_threshold && !visible_bounds.contains(region.position) {
                 to_remove.push(region.position);
                 self.compressed_regions.push(region.compress_region());
+                println!("Compressed region: {}", region.position);
             }
         }
 

--- a/src/sandsim.rs
+++ b/src/sandsim.rs
@@ -41,7 +41,7 @@ impl Plugin for SandSimulationPlugin {
             chunk_cull_time: VecDeque::new(),
             target_chunk_updates: 0,
         })
-        .add_systems(Update, create_spawned_chunks.in_set(crate::UpdateStages::WorldUpdate))
+        .add_systems(Update, (create_spawned_chunks, clear_removed_chunks).in_set(crate::UpdateStages::WorldUpdate))
         .add_systems(Update, sand_update.in_set(crate::UpdateStages::WorldUpdate))
         .add_systems(Update, update_chunk_textures.in_set(crate::UpdateStages::WorldDraw))
         .add_systems(Update, world_interact.in_set(crate::UpdateStages::Input))
@@ -157,6 +157,20 @@ fn create_spawned_chunks(
                     chunk_texture_handle: image_handle.clone(),
                     texture_dirty: false,
                 });
+        }
+    }
+}
+
+fn clear_removed_chunks(
+    mut world: ResMut<Sandworld>,
+    chunk_query: Query<(&mut Chunk, Entity)>,
+    mut commands: Commands,
+) {
+    let removed_chunks = world.world.get_removed_chunks();
+    
+    for (chunk, entity) in chunk_query.iter() {
+        if removed_chunks.contains(&chunk.chunk_pos) {
+            commands.entity(entity).despawn();
         }
     }
 }

--- a/src/sandsim.rs
+++ b/src/sandsim.rs
@@ -124,7 +124,6 @@ fn create_chunk_image(chunk: &sandworld::Chunk, draw_options: &DrawOptions) -> I
 }
 
 fn render_chunk_data(chunk: &sandworld::Chunk, draw_options: &DrawOptions) -> Vec<u8> {
-    let side_size = sandworld::CHUNK_SIZE as u32;
     chunk.render_to_color_array(draw_options.update_bounds, draw_options.chunk_bounds)
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -59,6 +59,14 @@ fn spawn_performance_info_text(mut commands: Commands, asset_server: Res<AssetSe
                     },
                 },
                 TextSection {
+                    value: "\nSleeping Regions: 000".to_string(),
+                    style: TextStyle {
+                        font: asset_server.load("fonts/FiraMono-Medium.ttf"),
+                        font_size: 20.0,
+                        color: Color::rgb(0.9, 0.9, 0.9),
+                    },
+                },
+                TextSection {
                     value: "\nUpdated Regions: 000".to_string(),
                     style: TextStyle {
                         font: asset_server.load("fonts/FiraMono-Medium.ttf"),
@@ -127,8 +135,9 @@ fn update_performance_text(
 
         if let Some(world_stats) = &stats.update_stats {
             text.sections[1].value = format!("\nLoaded Regions: {}", world_stats.loaded_regions);
-            text.sections[2].value = format!("\nRegion Updates: {}", world_stats.region_updates);
-            text.sections[3].value = format!(
+            text.sections[2].value = format!("\nCompressed Regions: {}", world_stats.compressed_regions);
+            text.sections[3].value = format!("\nRegion Updates: {}", world_stats.region_updates);
+            text.sections[4].value = format!(
                 "\nChunk Updates [Target]: {} [{}]",
                 world_stats.chunk_updates, stats.target_chunk_updates
             );
@@ -145,7 +154,7 @@ fn update_performance_text(
                 texture_update_per_chunk_avg =
                     texture_update_per_chunk_avg / (stats.chunk_texture_update_time.len() as f64);
 
-                text.sections[5].value = format!(
+                text.sections[6].value = format!(
                     "\nTex Update time:  {:.2}ms - Avg time per chunk: {:.3}ms",
                     texture_update_time_avg * 1000.,
                     texture_update_per_chunk_avg * 1000.
@@ -164,7 +173,7 @@ fn update_performance_text(
                 culled_chunks_avg =
                     culled_chunks_avg / stats.chunk_cull_time.len() as u64;
     
-                text.sections[6].value = format!(
+                text.sections[7].value = format!(
                     "\nChunk cull time:  {:.2}ms - Avg chunks culled: {:.3}",
                     cull_time_avg * 1000.,
                     culled_chunks_avg
@@ -184,7 +193,7 @@ fn update_performance_text(
         total_sand_update_second_avg =
             total_sand_update_second_avg / (stats.sand_update_time.len() as f64);
 
-        text.sections[4].value = format!(
+        text.sections[5].value = format!(
             "\nSand update time: {:.2}ms - Avg time per chunk: {:.3}ms",
             total_sand_update_second_avg * 1000.,
             1000. / chunk_updates_per_second_avg


### PR DESCRIPTION
Adds methods and types to Compress and Decompress regions and chunks. The world will put regions that have been deprioritized in updates enough to be starved for at least 12 update cycles to sleep, removing the region from simulation, compressing the chunks, and removing the sprites from the bevy rendering. Once that chunk is requested again, it is decompressed and re-added to the world - the same as when adding a newly chunk. Memory usage improvements for small worlds are negligible, but as worlds get bigger the gains get better.